### PR TITLE
feat: React Native notification service (Unit 10)

### DIFF
--- a/supercoach-ai-native/hooks/useNotifications.ts
+++ b/supercoach-ai-native/hooks/useNotifications.ts
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { AppState } from 'react-native';
+import type { NotificationSettings } from '../shared/types';
+import type { AlarmSlot } from '../services/notificationService';
+import {
+  registerForPushNotifications,
+  checkNotificationTriggers,
+  showNotification,
+  markMorningSent,
+  markEveningSent,
+  addNotificationResponseListener,
+} from '../services/notificationService';
+
+const CHECK_INTERVAL_MS = 60_000; // 1 minute
+
+// Re-export AlarmSlot from the service so consumers can import from either place
+export type { AlarmSlot } from '../services/notificationService';
+
+interface UseNotificationsOptions {
+  /** Current notification settings from user profile / store. */
+  settings: NotificationSettings | null;
+  /** Called when the user taps a notification. */
+  onNotificationTap?: (slot: AlarmSlot | null, data?: Record<string, unknown>) => void;
+  /** Called after a push token is obtained. */
+  onTokenReceived?: (token: string) => void;
+}
+
+export function useNotifications({
+  settings,
+  onNotificationTap,
+  onTokenReceived,
+}: UseNotificationsOptions) {
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // --- Trigger check callback ---
+  const runTriggerCheck = useCallback(async () => {
+    if (!settings) return;
+
+    const result = await checkNotificationTriggers(settings);
+
+    if (result.shouldNotifyMorning) {
+      await showNotification(
+        'Good morning!',
+        "Check today's goals and get started.",
+        { slot: 'morning' },
+      );
+      await markMorningSent();
+    }
+
+    if (result.shouldNotifyEvening) {
+      await showNotification(
+        'Evening check-in',
+        'How did today go? Review your progress.',
+        { slot: 'evening' },
+      );
+      await markEveningSent();
+    }
+  }, [settings]);
+
+  // --- Initialise on mount ---
+  useEffect(() => {
+    let mounted = true;
+
+    async function init() {
+      // registerForPushNotifications handles permissions + channel setup internally
+      const token = await registerForPushNotifications();
+      if (token && mounted) {
+        onTokenReceived?.(token);
+      }
+    }
+
+    init();
+
+    return () => {
+      mounted = false;
+    };
+    // Only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // --- Notification tap handler ---
+  useEffect(() => {
+    const sub = addNotificationResponseListener((response) => {
+      const data = response.notification.request.content.data as
+        | Record<string, unknown>
+        | undefined;
+      const slot = (data?.slot as AlarmSlot) ?? null;
+      onNotificationTap?.(slot, data);
+    });
+
+    return () => sub.remove();
+  }, [onNotificationTap]);
+
+  // --- Periodic trigger checking ---
+  useEffect(() => {
+    // Run immediately on settings change
+    runTriggerCheck();
+
+    intervalRef.current = setInterval(runTriggerCheck, CHECK_INTERVAL_MS);
+
+    // Pause when app is backgrounded, resume on foreground
+    const appStateSub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        runTriggerCheck();
+        if (!intervalRef.current) {
+          intervalRef.current = setInterval(runTriggerCheck, CHECK_INTERVAL_MS);
+        }
+      } else if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    });
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      appStateSub.remove();
+    };
+  }, [runTriggerCheck]);
+}

--- a/supercoach-ai-native/services/notificationService.ts
+++ b/supercoach-ai-native/services/notificationService.ts
@@ -1,0 +1,221 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { NotificationSettings } from '../shared/types';
+
+// ---------- Constants ----------
+
+const SENT_KEY = 'feedback_notif_sent';
+const TRIGGER_WINDOW_MS = 5 * 60 * 1000;
+const ANDROID_CHANNEL_ID = 'supercoach-default';
+
+export type AlarmSlot = 'morning' | 'evening';
+
+// ---------- Notification channel setup (Android) ----------
+
+export async function setupNotificationChannel(): Promise<void> {
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync(ANDROID_CHANNEL_ID, {
+      name: 'SuperCoach Notifications',
+      importance: Notifications.AndroidImportance.HIGH,
+      sound: 'default',
+      vibrationPattern: [0, 250, 250, 250],
+    });
+  }
+}
+
+// ---------- Foreground notification handler ----------
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: true,
+  }),
+});
+
+// ---------- Permission & registration ----------
+
+export async function requestPermissions(): Promise<boolean> {
+  const { status: existing } = await Notifications.getPermissionsAsync();
+  if (existing === 'granted') return true;
+
+  const { status } = await Notifications.requestPermissionsAsync();
+  return status === 'granted';
+}
+
+export async function registerForPushNotifications(): Promise<string | null> {
+  try {
+    const granted = await requestPermissions();
+    if (!granted) return null;
+
+    await setupNotificationChannel();
+
+    const { data: token } = await Notifications.getDevicePushTokenAsync();
+    return typeof token === 'string' ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------- Local notification helpers ----------
+
+export async function scheduleLocalNotification(
+  title: string,
+  body: string,
+  options?: {
+    trigger?: Notifications.NotificationTriggerInput;
+    data?: Record<string, unknown>;
+  },
+): Promise<string> {
+  return Notifications.scheduleNotificationAsync({
+    content: {
+      title,
+      body,
+      data: options?.data,
+      sound: 'default',
+      ...(Platform.OS === 'android' && { channelId: ANDROID_CHANNEL_ID }),
+    },
+    trigger: options?.trigger ?? null,
+  });
+}
+
+export async function showNotification(
+  title: string,
+  body: string,
+  data?: Record<string, unknown>,
+): Promise<void> {
+  await scheduleLocalNotification(title, body, { data });
+}
+
+export async function cancelAllNotifications(): Promise<void> {
+  await Notifications.cancelAllScheduledNotificationsAsync();
+}
+
+// ---------- Response listener ----------
+
+export function addNotificationResponseListener(
+  handler: (response: Notifications.NotificationResponse) => void,
+): Notifications.Subscription {
+  return Notifications.addNotificationResponseReceivedListener(handler);
+}
+
+// ---------- Sent-record persistence (AsyncStorage) ----------
+
+async function getSentRecord(): Promise<Record<string, string>> {
+  try {
+    const raw = await AsyncStorage.getItem(SENT_KEY);
+    return raw ? (JSON.parse(raw) as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function markSent(type: string, dateKey: string): Promise<void> {
+  const record = await getSentRecord();
+  record[`${type}_${dateKey}`] = new Date().toISOString();
+
+  // Prune entries older than 3 days
+  const cutoff = Date.now() - 3 * 86_400_000;
+  for (const [k, v] of Object.entries(record)) {
+    if (new Date(v).getTime() < cutoff) delete record[k];
+  }
+  await AsyncStorage.setItem(SENT_KEY, JSON.stringify(record));
+}
+
+function checkSent(
+  record: Record<string, string>,
+  type: string,
+  dateKey: string,
+  settingsUpdatedAt = 0,
+): boolean {
+  const sentAtIso = record[`${type}_${dateKey}`];
+  if (!sentAtIso) return false;
+  const sentAt = new Date(sentAtIso).getTime();
+  if (!Number.isFinite(sentAt)) return false;
+  return sentAt >= settingsUpdatedAt;
+}
+
+// ---------- Time utilities ----------
+
+function todayKey(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function isWithinWindow(targetTime: string, windowMs = TRIGGER_WINDOW_MS): boolean {
+  const now = new Date();
+  const [h, m] = targetTime.split(':').map(Number);
+  const target = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, m, 0);
+  const diff = now.getTime() - target.getTime();
+  return diff >= 0 && diff < windowMs;
+}
+
+function isPastTime(targetTime: string): boolean {
+  const now = new Date();
+  const [h, m] = targetTime.split(':').map(Number);
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+  return nowMinutes >= h * 60 + m;
+}
+
+// ---------- Trigger check result ----------
+
+export interface NotificationCheckResult {
+  shouldNotifyMorning: boolean;
+  shouldNotifyEvening: boolean;
+  shouldGenerateVictory: boolean;
+}
+
+export async function checkNotificationTriggers(
+  settings: NotificationSettings | null,
+): Promise<NotificationCheckResult> {
+  const result: NotificationCheckResult = {
+    shouldNotifyMorning: false,
+    shouldNotifyEvening: false,
+    shouldGenerateVictory: false,
+  };
+
+  if (!settings) return result;
+  const today = todayKey();
+  const settingsUpdatedAt = Number(settings.updatedAt || 0);
+  const record = await getSentRecord();
+
+  if (settings.morningEnabled && !checkSent(record, 'morning', today, settingsUpdatedAt)) {
+    if (isWithinWindow(settings.morningTime)) {
+      result.shouldNotifyMorning = true;
+    }
+  }
+
+  if (settings.eveningEnabled && !checkSent(record, 'evening', today, settingsUpdatedAt)) {
+    if (isWithinWindow(settings.eveningTime)) {
+      result.shouldNotifyEvening = true;
+    }
+  }
+
+  if (settings.eveningEnabled && isPastTime(settings.eveningTime)) {
+    if (!checkSent(record, 'victory', today)) {
+      result.shouldGenerateVictory = true;
+    }
+  }
+
+  return result;
+}
+
+// ---------- Mark helpers ----------
+
+export async function markMorningSent(): Promise<void> {
+  await markSent('morning', todayKey());
+}
+
+export async function markEveningSent(): Promise<void> {
+  await markSent('evening', todayKey());
+}
+
+export async function markVictoryGenerated(): Promise<void> {
+  await markSent('victory', todayKey());
+}
+
+export async function wasVictoryGenerated(): Promise<boolean> {
+  const record = await getSentRecord();
+  return checkSent(record, 'victory', todayKey());
+}


### PR DESCRIPTION
## Summary
- Rewrote the web notification service (`services/notificationService.ts`) for React Native using `expo-notifications`
- Replaced Web Notification API, ServiceWorker, and Firebase web SDK with expo-notifications local/push APIs
- Replaced `localStorage` with `@react-native-async-storage/async-storage` for dedup/cooldown tracking
- Added `useNotifications` hook with permission request, FCM token registration, periodic trigger checking, and AppState-aware interval management
- Preserved portable logic: `checkNotificationTriggers`, time-window checking, cooldown/dedup

## Test plan
- [ ] Verify Android notification channel is created on app start
- [ ] Verify permission request prompt appears on first launch
- [ ] Verify morning/evening notifications fire within the configured time window
- [ ] Verify dedup prevents duplicate notifications on the same day
- [ ] Verify interval pauses when app is backgrounded and resumes on foreground
- [ ] Verify tapping a notification invokes the `onNotificationTap` callback with correct slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)