### PR TITLE
feat: Todo List screen for React Native (Unit 4)

### DIFF
--- a/supercoach-ai-native/app.json
+++ b/supercoach-ai-native/app.json
@@ -1,0 +1,39 @@
+{
+  "expo": {
+    "name": "SuperCoach AI",
+    "slug": "supercoach-ai",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "scheme": "supercoach",
+    "userInterfaceStyle": "automatic",
+    "newArchEnabled": true,
+    "splash": {
+      "image": "./assets/splash-icon.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#0A0E1A"
+    },
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "com.supercoach.ai"
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#0A0E1A"
+      },
+      "package": "com.supercoach.ai"
+    },
+    "web": {
+      "bundler": "metro",
+      "output": "static",
+      "favicon": "./assets/favicon.png"
+    },
+    "plugins": [
+      "expo-router"
+    ],
+    "experiments": {
+      "typedRoutes": true
+    }
+  }
+}

--- a/supercoach-ai-native/app/(tabs)/todo.tsx
+++ b/supercoach-ai-native/app/(tabs)/todo.tsx
@@ -1,0 +1,356 @@
+import React, { useState, useMemo, useCallback } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  StyleSheet,
+  Alert,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import DraggableFlatList, {
+  RenderItemParams,
+  ScaleDecorator,
+} from 'react-native-draggable-flatlist';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { Plus, Search, X, ListTodo } from 'lucide-react-native';
+import type { ToDoItem, GoalNode } from '../../shared/types';
+import TodoItem from '../../components/todo/TodoItem';
+import TodoFilters, {
+  FilterType,
+  SortType,
+} from '../../components/todo/TodoFilters';
+import TodoEditModal from '../../components/todo/TodoEditModal';
+
+// ---------------------------------------------------------------------------
+// Sample data for development / demonstration
+// ---------------------------------------------------------------------------
+function createSampleTodos(): ToDoItem[] {
+  const now = Date.now();
+  return [
+    {
+      id: '1',
+      text: 'Review project requirements',
+      completed: false,
+      createdAt: now - 86400000 * 3,
+      priority: 'high',
+      dueDate: now + 86400000,
+      isMyDay: true,
+      tags: ['work'],
+    },
+    {
+      id: '2',
+      text: 'Design mobile UI mockups',
+      completed: false,
+      createdAt: now - 86400000 * 2,
+      priority: 'medium',
+      dueDate: now + 86400000 * 3,
+      linkedNodeText: 'App Redesign',
+      linkedGoalId: 'goal-1',
+    },
+    {
+      id: '3',
+      text: 'Write unit tests',
+      completed: true,
+      createdAt: now - 86400000 * 5,
+      priority: 'low',
+    },
+    {
+      id: '4',
+      text: 'Team standup meeting',
+      completed: false,
+      createdAt: now - 86400000,
+      repeat: 'weekdays',
+      isMyDay: true,
+    },
+    {
+      id: '5',
+      text: 'Update documentation',
+      completed: false,
+      createdAt: now,
+      priority: 'medium',
+      dueDate: now - 86400000, // overdue
+      tags: ['docs', 'important'],
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+export default function TodoScreen() {
+  const [todos, setTodos] = useState<ToDoItem[]>(createSampleTodos);
+  const [goals] = useState<GoalNode[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeFilter, setActiveFilter] = useState<FilterType>('all');
+  const [activeSort, setActiveSort] = useState<SortType>('created');
+  const [editingTodo, setEditingTodo] = useState<ToDoItem | null>(null);
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [quickAddText, setQuickAddText] = useState('');
+  const [showSearch, setShowSearch] = useState(false);
+
+  // ---- Derived counts (single pass) ----
+  const { pendingCount, completedCount } = useMemo(() => {
+    let completed = 0;
+    for (const t of todos) {
+      if (t.completed) completed++;
+    }
+    return { pendingCount: todos.length - completed, completedCount: completed };
+  }, [todos]);
+
+  // ---- Filter + sort ----
+  const displayedTodos = useMemo(() => {
+    let list = [...todos];
+
+    // Search
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      list = list.filter(
+        (t) =>
+          t.text.toLowerCase().includes(q) ||
+          t.note?.toLowerCase().includes(q) ||
+          t.tags?.some((tag) => tag.toLowerCase().includes(q)),
+      );
+    }
+
+    // Filter
+    if (activeFilter === 'pending') list = list.filter((t) => !t.completed);
+    if (activeFilter === 'completed') list = list.filter((t) => t.completed);
+
+    // Sort
+    list.sort((a, b) => {
+      switch (activeSort) {
+        case 'priority': {
+          const order: Record<string, number> = {
+            high: 0,
+            medium: 1,
+            low: 2,
+          };
+          return (
+            (order[a.priority ?? 'low'] ?? 3) -
+            (order[b.priority ?? 'low'] ?? 3)
+          );
+        }
+        case 'dueDate': {
+          const ad = a.dueDate ?? Infinity;
+          const bd = b.dueDate ?? Infinity;
+          return ad - bd;
+        }
+        case 'created':
+        default:
+          return b.createdAt - a.createdAt;
+      }
+    });
+
+    return list;
+  }, [todos, searchQuery, activeFilter, activeSort]);
+
+  // ---- Handlers ----
+  const handleToggle = useCallback((id: string) => {
+    setTodos((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, completed: !t.completed } : t)),
+    );
+  }, []);
+
+  const handleDelete = useCallback((id: string) => {
+    Alert.alert('Delete Task', 'Are you sure you want to delete this task?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: () => setTodos((prev) => prev.filter((t) => t.id !== id)),
+      },
+    ]);
+  }, []);
+
+  const handleSave = useCallback((data: Partial<ToDoItem>) => {
+    setTodos((prev) => {
+      const existing = prev.find((t) => t.id === data.id);
+      if (existing) {
+        return prev.map((t) => (t.id === data.id ? { ...t, ...data } : t));
+      }
+      return [data as ToDoItem, ...prev];
+    });
+  }, []);
+
+  const handleQuickAdd = useCallback(() => {
+    const text = quickAddText.trim();
+    if (!text) return;
+    const newTodo: ToDoItem = {
+      id: Date.now().toString(),
+      text,
+      completed: false,
+      createdAt: Date.now(),
+    };
+    setTodos((prev) => [newTodo, ...prev]);
+    setQuickAddText('');
+  }, [quickAddText]);
+
+  const handleDragEnd = useCallback(
+    ({ data }: { data: ToDoItem[] }) => {
+      setTodos(data.map((item, idx) => ({ ...item, sortOrder: idx })));
+    },
+    [],
+  );
+
+  const openEdit = useCallback((todo: ToDoItem) => {
+    setEditingTodo(todo);
+    setIsModalVisible(true);
+  }, []);
+
+  const openCreate = useCallback(() => {
+    setEditingTodo(null);
+    setIsModalVisible(true);
+  }, []);
+
+  // ---- Render item ----
+  const renderItem = useCallback(
+    ({ item, drag, isActive }: RenderItemParams<ToDoItem>) => (
+      <ScaleDecorator>
+        <TodoItem
+          todo={item}
+          onToggle={handleToggle}
+          onPress={openEdit}
+          drag={drag}
+          isActive={isActive}
+        />
+      </ScaleDecorator>
+    ),
+    [handleToggle, openEdit],
+  );
+
+  const keyExtractor = useCallback((item: ToDoItem) => item.id, []);
+
+  // ---- Empty state (stable reference) ----
+  const ListEmpty = useMemo(
+    () => (
+      <View className="flex-1 items-center justify-center py-20">
+        <ListTodo size={48} color="#4B5563" />
+        <Text className="text-gray-500 text-base mt-4">No tasks yet</Text>
+        <Text className="text-gray-600 text-sm mt-1">
+          Tap + to create your first task
+        </Text>
+      </View>
+    ),
+    [],
+  );
+
+  return (
+    <GestureHandlerRootView style={styles.root}>
+      <SafeAreaView className="flex-1 bg-background" edges={['top']}>
+        {/* Header */}
+        <View className="flex-row items-center justify-between px-5 pt-2 pb-3">
+          <Text className="text-2xl font-bold text-white tracking-wider">
+            Tasks
+          </Text>
+          <Pressable
+            onPress={() => setShowSearch(!showSearch)}
+            className="p-2 rounded-lg"
+          >
+            {showSearch ? (
+              <X size={22} color="#9CA3AF" />
+            ) : (
+              <Search size={22} color="#9CA3AF" />
+            )}
+          </Pressable>
+        </View>
+
+        {/* Search bar */}
+        {showSearch && (
+          <View className="px-4 pb-2">
+            <View className="flex-row items-center bg-surface border border-gray-700 rounded-xl overflow-hidden">
+              <Search size={16} color="#6B7280" style={{ marginLeft: 12 }} />
+              <TextInput
+                value={searchQuery}
+                onChangeText={setSearchQuery}
+                placeholder="Search tasks..."
+                placeholderTextColor="#4B5563"
+                className="flex-1 py-2.5 px-3 text-sm text-white"
+                autoFocus
+              />
+              {searchQuery.length > 0 && (
+                <Pressable
+                  onPress={() => setSearchQuery('')}
+                  className="p-2"
+                >
+                  <X size={14} color="#6B7280" />
+                </Pressable>
+              )}
+            </View>
+          </View>
+        )}
+
+        {/* Filters */}
+        <TodoFilters
+          activeFilter={activeFilter}
+          onFilterChange={setActiveFilter}
+          activeSort={activeSort}
+          onSortChange={setActiveSort}
+          totalCount={todos.length}
+          pendingCount={pendingCount}
+          completedCount={completedCount}
+        />
+
+        {/* Quick add bar */}
+        <View className="flex-row items-center gap-2 mx-4 mb-2">
+          <View className="flex-1 flex-row items-center bg-surface border border-gray-700 rounded-xl overflow-hidden">
+            <Plus size={18} color="#6B7280" style={{ marginLeft: 12 }} />
+            <TextInput
+              value={quickAddText}
+              onChangeText={setQuickAddText}
+              onSubmitEditing={handleQuickAdd}
+              placeholder="Quick add task..."
+              placeholderTextColor="#4B5563"
+              className="flex-1 py-2.5 px-3 text-sm text-white"
+              returnKeyType="done"
+            />
+          </View>
+        </View>
+
+        {/* Todo list */}
+        <DraggableFlatList
+          data={displayedTodos}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          onDragEnd={handleDragEnd}
+          containerStyle={styles.listContainer}
+          contentContainerStyle={styles.listContent}
+          ListEmptyComponent={ListEmpty}
+          activationDistance={10}
+        />
+
+        {/* FAB */}
+        <Pressable
+          onPress={openCreate}
+          className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-accent items-center justify-center shadow-lg"
+          style={styles.fab}
+        >
+          <Plus size={28} color="#000" />
+        </Pressable>
+
+        {/* Edit Modal */}
+        <TodoEditModal
+          visible={isModalVisible}
+          onClose={() => setIsModalVisible(false)}
+          todo={editingTodo}
+          goals={goals}
+          onSave={handleSave}
+          onDelete={handleDelete}
+        />
+      </SafeAreaView>
+    </GestureHandlerRootView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: '#0A0E1A' },
+  listContainer: { flex: 1 },
+  listContent: { paddingBottom: 100 },
+  fab: {
+    shadowColor: '#71B7FF',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 6,
+  },
+});

--- a/supercoach-ai-native/babel.config.js
+++ b/supercoach-ai-native/babel.config.js
@@ -1,0 +1,10 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: [
+      ["babel-preset-expo", { jsxImportSource: "nativewind" }],
+      "nativewind/babel",
+    ],
+    plugins: ["react-native-reanimated/plugin"],
+  };
+};

--- a/supercoach-ai-native/components/todo/TodoEditModal.tsx
+++ b/supercoach-ai-native/components/todo/TodoEditModal.tsx
@@ -1,0 +1,519 @@
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  ScrollView,
+  Modal,
+  Platform,
+  KeyboardAvoidingView,
+} from 'react-native';
+import {
+  X,
+  Save,
+  Trash2,
+  Calendar,
+  Repeat,
+  Target,
+  Tag,
+  AlertCircle,
+} from 'lucide-react-native';
+import type {
+  ToDoItem,
+  GoalNode,
+  RepeatFrequency,
+  TodoPriority,
+} from '../../shared/types';
+import { REPEAT_LABELS } from '../../shared/constants';
+
+interface TodoEditModalProps {
+  visible: boolean;
+  onClose: () => void;
+  todo: ToDoItem | null;
+  goals: GoalNode[];
+  onSave: (todo: Partial<ToDoItem>) => void;
+  onDelete?: (id: string) => void;
+}
+
+const REPEAT_OPTIONS: { value: RepeatFrequency; label: string }[] = [
+  { value: null, label: 'No Repeat' },
+  ...(['daily', 'weekdays', 'weekly', 'weekly-2', 'weekly-3', 'monthly'] as const).map(
+    (v) => ({ value: v as RepeatFrequency, label: REPEAT_LABELS[v] ?? v }),
+  ),
+];
+
+const PRIORITY_OPTIONS: {
+  value: TodoPriority;
+  label: string;
+  color: string;
+  bg: string;
+  border: string;
+}[] = [
+  {
+    value: 'low',
+    label: 'Low',
+    color: 'text-gray-400',
+    bg: 'bg-gray-800',
+    border: 'border-gray-600',
+  },
+  {
+    value: 'medium',
+    label: 'Medium',
+    color: 'text-orange-400',
+    bg: 'bg-orange-900/30',
+    border: 'border-orange-500/50',
+  },
+  {
+    value: 'high',
+    label: 'High',
+    color: 'text-red-400',
+    bg: 'bg-red-900/30',
+    border: 'border-red-500/50',
+  },
+];
+
+const EMPTY_FORM: Partial<ToDoItem> = {
+  text: '',
+  priority: 'medium',
+  dueDate: null,
+  linkedGoalId: undefined,
+  repeat: null,
+  tags: [],
+  note: '',
+};
+
+const TodoEditModal: React.FC<TodoEditModalProps> = ({
+  visible,
+  onClose,
+  todo,
+  goals,
+  onSave,
+  onDelete,
+}) => {
+  const [formData, setFormData] = useState<Partial<ToDoItem>>(EMPTY_FORM);
+  const [tagInput, setTagInput] = useState('');
+  const [showRepeatPicker, setShowRepeatPicker] = useState(false);
+  const [showGoalPicker, setShowGoalPicker] = useState(false);
+
+  useEffect(() => {
+    if (todo) {
+      setFormData({
+        ...todo,
+        linkedGoalId: todo.linkedGoalId ?? todo.linkedNodeId,
+      });
+    } else {
+      setFormData({ ...EMPTY_FORM });
+    }
+    setTagInput('');
+    setShowRepeatPicker(false);
+    setShowGoalPicker(false);
+  }, [todo, visible]);
+
+  const handleSave = () => {
+    if (!formData.text?.trim()) return;
+    const data: Partial<ToDoItem> = {
+      ...formData,
+      linkedNodeId: formData.linkedGoalId,
+      linkedNodeText: goals.find((g) => g.id === formData.linkedGoalId)?.text,
+    };
+    if (!todo) {
+      data.id = Date.now().toString();
+      data.createdAt = Date.now();
+      data.completed = false;
+    }
+    onSave(data);
+    onClose();
+  };
+
+  const handleAddTag = () => {
+    const trimmed = tagInput.trim();
+    if (trimmed && !formData.tags?.includes(trimmed)) {
+      setFormData({ ...formData, tags: [...(formData.tags ?? []), trimmed] });
+      setTagInput('');
+    }
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    setFormData({
+      ...formData,
+      tags: formData.tags?.filter((t) => t !== tag) ?? [],
+    });
+  };
+
+  const formatDateForDisplay = (ts?: number | null): string => {
+    if (!ts) return 'Not set';
+    return new Date(ts).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        className="flex-1 bg-background"
+      >
+        {/* Header */}
+        <View className="flex-row items-center justify-between px-5 py-4 border-b border-gray-700/50">
+          <Text className="text-xl font-bold text-white tracking-wider">
+            {todo ? 'EDIT TASK' : 'NEW TASK'}
+          </Text>
+          <Pressable onPress={onClose} className="p-2 rounded-lg">
+            <X size={24} color="#9CA3AF" />
+          </Pressable>
+        </View>
+
+        {/* Body */}
+        <ScrollView
+          className="flex-1 px-5"
+          contentContainerStyle={{ paddingVertical: 20, gap: 20 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Title */}
+          <View className="gap-2">
+            <View className="flex-row items-center gap-2">
+              <AlertCircle size={14} color="#9CA3AF" />
+              <Text className="text-xs font-bold text-gray-400 tracking-wider uppercase">
+                Task Description
+              </Text>
+            </View>
+            <TextInput
+              value={formData.text ?? ''}
+              onChangeText={(text) => setFormData({ ...formData, text })}
+              placeholder="What needs to be done?"
+              placeholderTextColor="#4B5563"
+              className="bg-surface border border-gray-700 rounded-xl px-4 py-3 text-white text-base"
+              autoFocus={!todo}
+            />
+          </View>
+
+          {/* Priority */}
+          <View className="gap-2">
+            <View className="flex-row items-center gap-2">
+              <AlertCircle size={14} color="#9CA3AF" />
+              <Text className="text-xs font-bold text-gray-400 tracking-wider uppercase">
+                Priority
+              </Text>
+            </View>
+            <View className="flex-row gap-2">
+              {PRIORITY_OPTIONS.map(({ value, label, color, bg, border }) => {
+                const active = formData.priority === value;
+                return (
+                  <Pressable
+                    key={value}
+                    onPress={() =>
+                      setFormData({ ...formData, priority: value })
+                    }
+                    className={`flex-1 items-center py-3 rounded-xl border-2 ${
+                      active ? `${bg} ${border}` : 'bg-surface border-gray-700'
+                    }`}
+                  >
+                    <Text
+                      className={`text-sm font-bold ${
+                        active ? color : 'text-gray-500'
+                      }`}
+                    >
+                      {label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+
+          {/* Due Date */}
+          <View className="gap-2">
+            <View className="flex-row items-center gap-2">
+              <Calendar size={14} color="#9CA3AF" />
+              <Text className="text-xs font-bold text-gray-400 tracking-wider uppercase">
+                Due Date
+              </Text>
+            </View>
+            <View className="flex-row gap-2">
+              <Pressable
+                onPress={() =>
+                  setFormData({ ...formData, dueDate: Date.now() })
+                }
+                className="flex-1 bg-surface border border-gray-700 rounded-xl px-4 py-3"
+              >
+                <Text className="text-gray-300 text-sm">
+                  {formatDateForDisplay(formData.dueDate)}
+                </Text>
+              </Pressable>
+              {formData.dueDate != null && (
+                <Pressable
+                  onPress={() => setFormData({ ...formData, dueDate: null })}
+                  className="items-center justify-center px-3 bg-surface border border-gray-700 rounded-xl"
+                >
+                  <X size={16} color="#6B7280" />
+                </Pressable>
+              )}
+            </View>
+            {/* Quick date buttons */}
+            <View className="flex-row gap-2">
+              <Pressable
+                onPress={() =>
+                  setFormData({ ...formData, dueDate: Date.now() })
+                }
+                className="px-3 py-1.5 rounded-lg bg-surface border border-gray-700"
+              >
+                <Text className="text-xs text-gray-400">Today</Text>
+              </Pressable>
+              <Pressable
+                onPress={() =>
+                  setFormData({
+                    ...formData,
+                    dueDate: Date.now() + 86400000,
+                  })
+                }
+                className="px-3 py-1.5 rounded-lg bg-surface border border-gray-700"
+              >
+                <Text className="text-xs text-gray-400">Tomorrow</Text>
+              </Pressable>
+              <Pressable
+                onPress={() =>
+                  setFormData({
+                    ...formData,
+                    dueDate: Date.now() + 7 * 86400000,
+                  })
+                }
+                className="px-3 py-1.5 rounded-lg bg-surface border border-gray-700"
+              >
+                <Text className="text-xs text-gray-400">Next Week</Text>
+              </Pressable>
+            </View>
+          </View>
+
+          {/* Repeat */}
+          <View className="gap-2">
+            <View className="flex-row items-center gap-2">
+              <Repeat size={14} color="#9CA3AF" />
+              <Text className="text-xs font-bold text-gray-400 tracking-wider uppercase">
+                Repeat
+              </Text>
+            </View>
+            <Pressable
+              onPress={() => setShowRepeatPicker(!showRepeatPicker)}
+              className="bg-surface border border-gray-700 rounded-xl px-4 py-3"
+            >
+              <Text className="text-gray-300 text-sm">
+                {REPEAT_OPTIONS.find((r) => r.value === formData.repeat)
+                  ?.label ?? 'No Repeat'}
+              </Text>
+            </Pressable>
+            {showRepeatPicker && (
+              <View className="bg-surface border border-gray-700 rounded-xl p-2">
+                {REPEAT_OPTIONS.map(({ value, label }) => (
+                  <Pressable
+                    key={value ?? 'none'}
+                    onPress={() => {
+                      setFormData({ ...formData, repeat: value });
+                      setShowRepeatPicker(false);
+                    }}
+                    className={`px-3 py-2 rounded-lg ${
+                      formData.repeat === value ? 'bg-accent' : ''
+                    }`}
+                  >
+                    <Text
+                      className={`text-sm ${
+                        formData.repeat === value
+                          ? 'text-black font-bold'
+                          : 'text-gray-400'
+                      }`}
+                    >
+                      {label}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            )}
+          </View>
+
+          {/* Link to Goal */}
+          {goals.length > 0 && (
+            <View className="gap-2">
+              <View className="flex-row items-center gap-2">
+                <Target size={14} color="#9CA3AF" />
+                <Text className="text-xs font-bold text-gray-400 tracking-wider uppercase">
+                  Link to Goal
+                </Text>
+              </View>
+              <Pressable
+                onPress={() => setShowGoalPicker(!showGoalPicker)}
+                className="bg-surface border border-gray-700 rounded-xl px-4 py-3"
+              >
+                <Text className="text-gray-300 text-sm">
+                  {goals.find((g) => g.id === formData.linkedGoalId)?.text ??
+                    'No linked goal'}
+                </Text>
+              </Pressable>
+              {showGoalPicker && (
+                <View className="bg-surface border border-gray-700 rounded-xl p-2 max-h-[200px]">
+                  <ScrollView nestedScrollEnabled>
+                    <Pressable
+                      onPress={() => {
+                        setFormData({
+                          ...formData,
+                          linkedGoalId: undefined,
+                        });
+                        setShowGoalPicker(false);
+                      }}
+                      className="px-3 py-2 rounded-lg"
+                    >
+                      <Text className="text-sm text-gray-500">
+                        No linked goal
+                      </Text>
+                    </Pressable>
+                    {goals
+                      .filter((g) => g.id !== 'root')
+                      .map((goal) => (
+                        <Pressable
+                          key={goal.id}
+                          onPress={() => {
+                            setFormData({
+                              ...formData,
+                              linkedGoalId: goal.id,
+                            });
+                            setShowGoalPicker(false);
+                          }}
+                          className={`px-3 py-2 rounded-lg ${
+                            formData.linkedGoalId === goal.id
+                              ? 'bg-accent'
+                              : ''
+                          }`}
+                        >
+                          <Text
+                            className={`text-sm ${
+                              formData.linkedGoalId === goal.id
+                                ? 'text-black font-bold'
+                                : 'text-gray-300'
+                            }`}
+                          >
+                            {goal.text}
+                          </Text>
+                        </Pressable>
+                      ))}
+                  </ScrollView>
+                </View>
+              )}
+            </View>
+          )}
+
+          {/* Tags */}
+          <View className="gap-2">
+            <View className="flex-row items-center gap-2">
+              <Tag size={14} color="#9CA3AF" />
+              <Text className="text-xs font-bold text-gray-400 tracking-wider uppercase">
+                Tags
+              </Text>
+            </View>
+            <View className="flex-row gap-2">
+              <TextInput
+                value={tagInput}
+                onChangeText={setTagInput}
+                onSubmitEditing={handleAddTag}
+                placeholder="Add tag"
+                placeholderTextColor="#4B5563"
+                className="flex-1 bg-surface border border-gray-700 rounded-xl px-4 py-2 text-white text-sm"
+                returnKeyType="done"
+              />
+              <Pressable
+                onPress={handleAddTag}
+                className="items-center justify-center px-4 bg-accent/20 border border-accent/30 rounded-xl"
+              >
+                <Text className="text-accent font-bold text-sm">Add</Text>
+              </Pressable>
+            </View>
+            {formData.tags != null && formData.tags.length > 0 && (
+              <View className="flex-row flex-wrap gap-2 mt-1">
+                {formData.tags.map((tag, idx) => (
+                  <View
+                    key={idx}
+                    className="flex-row items-center gap-1.5 px-3 py-1 bg-accent/10 border border-accent/20 rounded-full"
+                  >
+                    <Text className="text-sm text-accent">#{tag}</Text>
+                    <Pressable onPress={() => handleRemoveTag(tag)}>
+                      <X size={12} color="#EF4444" />
+                    </Pressable>
+                  </View>
+                ))}
+              </View>
+            )}
+          </View>
+
+          {/* Notes */}
+          <View className="gap-2">
+            <Text className="text-xs font-bold text-gray-400 tracking-wider uppercase">
+              Notes
+            </Text>
+            <TextInput
+              value={formData.note ?? ''}
+              onChangeText={(note) => setFormData({ ...formData, note })}
+              placeholder="Additional notes..."
+              placeholderTextColor="#4B5563"
+              multiline
+              numberOfLines={4}
+              textAlignVertical="top"
+              className="bg-surface border border-gray-700 rounded-xl px-4 py-3 text-white text-sm min-h-[100px]"
+            />
+          </View>
+        </ScrollView>
+
+        {/* Footer */}
+        <View className="flex-row items-center justify-between px-5 py-4 border-t border-gray-700/50">
+          {todo && onDelete ? (
+            <Pressable
+              onPress={() => {
+                onDelete(todo.id);
+                onClose();
+              }}
+              className="flex-row items-center gap-2 px-4 py-2.5 bg-red-500/10 border border-red-500/30 rounded-xl"
+            >
+              <Trash2 size={16} color="#F87171" />
+              <Text className="text-red-400 font-bold">Delete</Text>
+            </Pressable>
+          ) : (
+            <View />
+          )}
+
+          <View className="flex-row gap-3">
+            <Pressable
+              onPress={onClose}
+              className="px-5 py-2.5 bg-surface border border-gray-700 rounded-xl"
+            >
+              <Text className="text-gray-400 font-bold">Cancel</Text>
+            </Pressable>
+            <Pressable
+              onPress={handleSave}
+              disabled={!formData.text?.trim()}
+              className={`flex-row items-center gap-2 px-5 py-2.5 rounded-xl ${
+                formData.text?.trim()
+                  ? 'bg-accent'
+                  : 'bg-gray-700 opacity-50'
+              }`}
+            >
+              <Save size={16} color={formData.text?.trim() ? '#000' : '#666'} />
+              <Text
+                className={`font-bold ${
+                  formData.text?.trim() ? 'text-black' : 'text-gray-500'
+                }`}
+              >
+                {todo ? 'Update' : 'Create'}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+};
+
+export default TodoEditModal;

--- a/supercoach-ai-native/components/todo/TodoFilters.tsx
+++ b/supercoach-ai-native/components/todo/TodoFilters.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { View, Text, Pressable, ScrollView } from 'react-native';
+import { Filter, ArrowUpDown } from 'lucide-react-native';
+
+export type FilterType = 'all' | 'pending' | 'completed';
+export type SortType = 'dueDate' | 'priority' | 'created';
+
+interface TodoFiltersProps {
+  activeFilter: FilterType;
+  onFilterChange: (filter: FilterType) => void;
+  activeSort: SortType;
+  onSortChange: (sort: SortType) => void;
+  totalCount: number;
+  pendingCount: number;
+  completedCount: number;
+}
+
+const FILTERS: { value: FilterType; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'completed', label: 'Done' },
+];
+
+const SORT_OPTIONS: { value: SortType; label: string }[] = [
+  { value: 'dueDate', label: 'Date' },
+  { value: 'priority', label: 'Priority' },
+  { value: 'created', label: 'Created' },
+];
+
+function getCount(
+  filter: FilterType,
+  total: number,
+  pending: number,
+  completed: number,
+): number {
+  switch (filter) {
+    case 'all':
+      return total;
+    case 'pending':
+      return pending;
+    case 'completed':
+      return completed;
+  }
+}
+
+const TodoFilters: React.FC<TodoFiltersProps> = ({
+  activeFilter,
+  onFilterChange,
+  activeSort,
+  onSortChange,
+  totalCount,
+  pendingCount,
+  completedCount,
+}) => {
+  const [showSortMenu, setShowSortMenu] = React.useState(false);
+
+  return (
+    <View className="px-4 py-2 gap-2">
+      {/* Filter chips */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ gap: 8, alignItems: 'center' }}
+      >
+        <Filter size={14} color="#9CA3AF" />
+        {FILTERS.map(({ value, label }) => {
+          const active = activeFilter === value;
+          const count = getCount(value, totalCount, pendingCount, completedCount);
+          return (
+            <Pressable
+              key={value}
+              onPress={() => onFilterChange(value)}
+              className={`px-4 py-2 rounded-lg flex-row items-center ${
+                active ? 'bg-accent' : 'bg-surface'
+              }`}
+            >
+              <Text
+                className={`text-sm font-bold ${
+                  active ? 'text-black' : 'text-gray-400'
+                }`}
+              >
+                {label}
+              </Text>
+              <View
+                className={`ml-2 px-1.5 py-0.5 rounded-full ${
+                  active ? 'bg-black/20' : 'bg-gray-700'
+                }`}
+              >
+                <Text
+                  className={`text-xs ${
+                    active ? 'text-black/70' : 'text-gray-500'
+                  }`}
+                >
+                  {count}
+                </Text>
+              </View>
+            </Pressable>
+          );
+        })}
+
+        {/* Sort button */}
+        <Pressable
+          onPress={() => setShowSortMenu(!showSortMenu)}
+          className="flex-row items-center gap-1.5 px-3 py-2 rounded-lg bg-surface ml-2"
+        >
+          <ArrowUpDown size={14} color="#9CA3AF" />
+          <Text className="text-xs font-bold text-gray-400">
+            {SORT_OPTIONS.find((s) => s.value === activeSort)?.label}
+          </Text>
+        </Pressable>
+      </ScrollView>
+
+      {/* Sort dropdown */}
+      {showSortMenu && (
+        <View className="absolute right-4 top-14 z-50 bg-surface border border-gray-700 rounded-xl p-2 min-w-[140px] shadow-lg">
+          {SORT_OPTIONS.map(({ value, label }) => (
+            <Pressable
+              key={value}
+              onPress={() => {
+                onSortChange(value);
+                setShowSortMenu(false);
+              }}
+              className={`px-3 py-2 rounded-lg ${
+                activeSort === value ? 'bg-accent' : ''
+              }`}
+            >
+              <Text
+                className={`text-sm ${
+                  activeSort === value
+                    ? 'text-black font-bold'
+                    : 'text-gray-400'
+                }`}
+              >
+                {label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+};
+
+export default TodoFilters;

--- a/supercoach-ai-native/components/todo/TodoItem.tsx
+++ b/supercoach-ai-native/components/todo/TodoItem.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import Animated, {
+  useAnimatedStyle,
+  withTiming,
+  interpolateColor,
+  useSharedValue,
+  withSequence,
+  withSpring,
+} from 'react-native-reanimated';
+import {
+  Circle,
+  CheckCircle2,
+  Calendar,
+  Target,
+  Sun,
+  Repeat,
+  GripVertical,
+} from 'lucide-react-native';
+import type { ToDoItem } from '../../shared/types';
+import { getRepeatLabel } from '../../shared/constants';
+
+interface TodoItemProps {
+  todo: ToDoItem;
+  onToggle: (id: string) => void;
+  onPress: (todo: ToDoItem) => void;
+  drag?: () => void;
+  isActive?: boolean;
+}
+
+const PRIORITY_BG: Record<string, string> = {
+  high: 'bg-red-500',
+  medium: 'bg-orange-500',
+  low: 'bg-green-500',
+};
+
+function formatDate(timestamp?: number | null): string | null {
+  if (!timestamp) return null;
+  return new Date(timestamp).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    weekday: 'short',
+  });
+}
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+const TodoItem: React.FC<TodoItemProps> = ({
+  todo,
+  onToggle,
+  onPress,
+  drag,
+  isActive = false,
+}) => {
+  const checkScale = useSharedValue(1);
+  const isOverdue = todo.dueDate && todo.dueDate < Date.now() && !todo.completed;
+
+  const handleToggle = () => {
+    checkScale.value = withSequence(
+      withSpring(1.3, { damping: 4 }),
+      withSpring(1),
+    );
+    onToggle(todo.id);
+  };
+
+  const checkAnimStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: checkScale.value }],
+  }));
+
+  const containerStyle = useAnimatedStyle(() => ({
+    opacity: withTiming(todo.completed ? 0.5 : 1, { duration: 200 }),
+    backgroundColor: interpolateColor(
+      isActive ? 1 : 0,
+      [0, 1],
+      ['rgba(26, 31, 46, 0.8)', 'rgba(26, 31, 46, 1)'],
+    ),
+    transform: [{ scale: withTiming(isActive ? 1.03 : 1, { duration: 150 }) }],
+  }));
+
+  return (
+    <AnimatedPressable
+      onPress={() => onPress(todo)}
+      onLongPress={drag}
+      disabled={isActive}
+      style={[
+        containerStyle,
+        isActive && {
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 8 },
+          shadowOpacity: 0.3,
+          shadowRadius: 12,
+          elevation: 8,
+        },
+      ]}
+      className="flex-row items-center gap-3 px-4 py-3 mx-3 mb-2 rounded-2xl border border-gray-700/50"
+    >
+      {/* Priority indicator */}
+      {todo.priority && (
+        <View
+          className={`absolute left-0 top-1/4 w-1 h-1/2 rounded-r-full ${
+            PRIORITY_BG[todo.priority] ?? 'bg-gray-700'
+          }`}
+        />
+      )}
+
+      {/* Checkbox */}
+      <Animated.View style={checkAnimStyle}>
+        <Pressable onPress={handleToggle} hitSlop={8}>
+          {todo.completed ? (
+            <CheckCircle2 size={24} color="#71B7FF" />
+          ) : (
+            <Circle size={24} color="#6B7280" />
+          )}
+        </Pressable>
+      </Animated.View>
+
+      {/* Content */}
+      <View className="flex-1 min-w-0">
+        <Text
+          numberOfLines={2}
+          className={`text-base ${
+            todo.completed
+              ? 'line-through text-gray-500'
+              : 'text-white font-medium'
+          }`}
+        >
+          {todo.text}
+        </Text>
+
+        {/* Badges row */}
+        <View className="flex-row flex-wrap gap-1.5 mt-1.5">
+          {todo.isMyDay && (
+            <View className="flex-row items-center gap-1 px-2 py-0.5 rounded-full bg-yellow-400/10 border border-yellow-400/20">
+              <Sun size={10} color="#FACC15" />
+              <Text className="text-[10px] text-yellow-400">Today</Text>
+            </View>
+          )}
+
+          {todo.dueDate != null && (
+            <View
+              className={`flex-row items-center gap-1 px-2 py-0.5 rounded-full border ${
+                isOverdue
+                  ? 'bg-red-400/10 border-red-400/20'
+                  : 'bg-gray-800 border-gray-700'
+              }`}
+            >
+              <Calendar size={10} color={isOverdue ? '#F87171' : '#9CA3AF'} />
+              <Text
+                className={`text-[10px] ${
+                  isOverdue ? 'text-red-400' : 'text-gray-400'
+                }`}
+              >
+                {formatDate(todo.dueDate)}
+              </Text>
+            </View>
+          )}
+
+          {todo.repeat && (
+            <View className="flex-row items-center gap-1 px-2 py-0.5 rounded-full bg-blue-400/10 border border-blue-400/20">
+              <Repeat size={10} color="#60A5FA" />
+              <Text className="text-[10px] text-blue-400">
+                {getRepeatLabel(todo.repeat)}
+              </Text>
+            </View>
+          )}
+
+          {(todo.linkedNodeText || todo.linkedGoalId) && (
+            <View className="flex-row items-center gap-1 px-2 py-0.5 rounded-full bg-orange-400/10 border border-orange-400/20">
+              <Target size={10} color="#FB923C" />
+              <Text
+                numberOfLines={1}
+                className="text-[10px] text-orange-400 max-w-[100px]"
+              >
+                {todo.linkedNodeText ?? 'Goal'}
+              </Text>
+            </View>
+          )}
+
+          {todo.tags != null &&
+            todo.tags.length > 0 &&
+            todo.tags.slice(0, 2).map((tag, idx) => (
+              <View
+                key={idx}
+                className="px-2 py-0.5 rounded-full bg-accent/10 border border-accent/20"
+              >
+                <Text className="text-[10px] text-accent">#{tag}</Text>
+              </View>
+            ))}
+          {todo.tags != null && todo.tags.length > 2 && (
+            <View className="px-2 py-0.5 rounded-full bg-gray-800">
+              <Text className="text-[10px] text-gray-500">
+                +{todo.tags.length - 2}
+              </Text>
+            </View>
+          )}
+        </View>
+      </View>
+
+      {/* Drag handle */}
+      {!todo.completed && (
+        <Pressable onLongPress={drag} hitSlop={8} className="p-1">
+          <GripVertical size={18} color="#4B5563" />
+        </Pressable>
+      )}
+    </AnimatedPressable>
+  );
+};
+
+export default React.memo(TodoItem);

--- a/supercoach-ai-native/global.css
+++ b/supercoach-ai-native/global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/supercoach-ai-native/metro.config.js
+++ b/supercoach-ai-native/metro.config.js
@@ -1,0 +1,6 @@
+const { getDefaultConfig } = require("expo/metro-config");
+const { withNativeWind } = require("nativewind/metro");
+
+const config = getDefaultConfig(__dirname);
+
+module.exports = withNativeWind(config, { input: "./global.css" });

--- a/supercoach-ai-native/nativewind-env.d.ts
+++ b/supercoach-ai-native/nativewind-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="nativewind/types" />

--- a/supercoach-ai-native/package.json
+++ b/supercoach-ai-native/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "supercoach-ai-native",
+  "version": "1.0.0",
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@gorhom/bottom-sheet": "^5",
+    "@react-native-async-storage/async-storage": "^2.1.2",
+    "@react-native-firebase/app": "^21.7.2",
+    "@react-native-firebase/auth": "^21.7.2",
+    "@react-native-firebase/firestore": "^21.7.2",
+    "expo": "~52.0.0",
+    "expo-av": "~15.0.0",
+    "expo-constants": "~17.0.0",
+    "expo-haptics": "~14.0.0",
+    "expo-image": "~2.0.0",
+    "expo-image-picker": "~16.0.0",
+    "expo-linking": "~7.0.0",
+    "expo-notifications": "~0.29.0",
+    "expo-router": "~4.0.0",
+    "expo-status-bar": "~2.0.0",
+    "lucide-react-native": "^0.468.0",
+    "nativewind": "^4.1.23",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-native": "0.76.7",
+    "react-native-draggable-flatlist": "^4.0.1",
+    "react-native-gesture-handler": "~2.20.0",
+    "react-native-reanimated": "~3.16.0",
+    "react-native-reanimated-carousel": "^4.0.2",
+    "react-native-safe-area-context": "~4.14.0",
+    "react-native-screens": "~4.4.0",
+    "react-native-svg": "~15.11.0",
+    "react-native-web": "~0.19.13",
+    "zustand": "^5.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.0",
+    "@types/react": "~18.3.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "~5.3.3"
+  },
+  "private": true
+}

--- a/supercoach-ai-native/shared/constants.ts
+++ b/supercoach-ai-native/shared/constants.ts
@@ -1,0 +1,19 @@
+import type { RepeatFrequency } from './types';
+
+/** Human-readable labels for repeat frequencies. */
+export const REPEAT_LABELS: Record<string, string> = {
+  daily: 'Daily',
+  weekdays: 'Weekdays',
+  weekly: 'Weekly',
+  'weekly-2': '2x/week',
+  'weekly-3': '3x/week',
+  'weekly-4': '4x/week',
+  'weekly-5': '5x/week',
+  'weekly-6': '6x/week',
+  monthly: 'Monthly',
+};
+
+export function getRepeatLabel(freq: RepeatFrequency | undefined): string | null {
+  if (!freq) return null;
+  return REPEAT_LABELS[freq] ?? freq;
+}

--- a/supercoach-ai-native/shared/types.ts
+++ b/supercoach-ai-native/shared/types.ts
@@ -1,0 +1,199 @@
+
+export enum NodeType {
+  ROOT = 'ROOT',
+  SUB = 'SUB',
+}
+
+export enum NodeStatus {
+  PENDING = 'PENDING',
+  COMPLETED = 'COMPLETED',
+  STUCK = 'STUCK',
+}
+
+export interface GoalNode {
+  id: string;
+  text: string;
+  type: NodeType;
+  status: NodeStatus;
+  progress: number;
+  parentId?: string;
+  imageUrl?: string;
+  collapsed?: boolean;
+  isPreview?: boolean;
+  x?: number;
+  y?: number;
+  vx?: number;
+  vy?: number;
+  fx?: number | null;
+  fy?: number | null;
+  sortOrder?: number;
+}
+
+export interface GoalLink {
+  source: string | GoalNode;
+  target: string | GoalNode;
+}
+
+export interface ChatMessage {
+  id: string;
+  sender: 'user' | 'ai';
+  text: string;
+  timestamp: number;
+  imageDataUrl?: string;
+}
+
+export interface UserProfile {
+  name: string;
+  email?: string;
+  gender: 'Male' | 'Female' | 'Other';
+  age: string;
+  location: string;
+  avatarUrl?: string;
+  googleId?: string;
+  bio?: string;
+  gallery?: string[];
+  billingPlan?: 'explorer' | 'essential' | 'visionary' | 'master' | null;
+  billingIsActive?: boolean;
+  billingSubscriptionId?: string | null;
+  billingCancelAtPeriodEnd?: boolean;
+  createdAt?: number;
+  onboardingCompleted?: boolean;
+}
+
+export type RepeatFrequency =
+  | 'daily'
+  | 'weekdays'
+  | 'weekly'
+  | 'monthly'
+  | 'weekly-2'
+  | 'weekly-3'
+  | 'weekly-4'
+  | 'weekly-5'
+  | 'weekly-6'
+  | null;
+
+export type TodoPriority = 'low' | 'medium' | 'high';
+
+export type SmartListId = 'myDay' | 'important' | 'planned' | 'tasks';
+
+export interface TodoList {
+  id: string;
+  name: string;
+  icon?: string;
+  color?: string;
+  groupId?: string;
+  sortOrder: number;
+  createdAt: number;
+}
+
+export interface TodoGroup {
+  id: string;
+  name: string;
+  isCollapsed: boolean;
+  sortOrder: number;
+  createdAt: number;
+}
+
+export interface ToDoItem {
+  id: string;
+  text: string;
+  completed: boolean;
+  linkedNodeId?: string;
+  linkedNodeText?: string;
+  linkedGoalId?: string;
+  createdAt: number;
+  isMyDay?: boolean;
+  dueDate?: number | null;
+  reminder?: number | null;
+  repeat?: RepeatFrequency;
+  note?: string;
+  priority?: TodoPriority;
+  tags?: string[];
+  listId?: string;
+  sortOrder?: number;
+  steps?: TodoStep[];
+}
+
+export interface TodoStep {
+  id: string;
+  text: string;
+  completed: boolean;
+}
+
+export interface UserPrinciple {
+  id: string;
+  text: string;
+  createdAt: number;
+  isRepresentative?: boolean;
+}
+
+export type ActionType =
+  | 'ADD_NODE' | 'UPDATE_NODE' | 'DELETE_NODE' | 'COMPLETE_NODE'
+  | 'ADD_TODO' | 'COMPLETE_TODO' | 'DELETE_TODO' | 'UPDATE_TODO'
+  | 'UPDATE_PROGRESS' | 'UPDATE_PROFILE' | 'VIEW_TAB'
+  | 'CREATE_VISUALIZATION' | 'OPEN_COACH' | 'COACH_CONVERSATION';
+
+export interface ActionLogEntry {
+  id: string;
+  action: ActionType;
+  detail: string;
+  timestamp: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ShortTermMemory {
+  summary: string;
+  lastActionTimestamp: number;
+  updatedAt: number;
+}
+
+export interface MidTermMemory {
+  summary: string;
+  updatedAt: number;
+}
+
+export interface LongTermMemory {
+  summary: string;
+  updatedAt: number;
+}
+
+export interface CoachMemoryContext {
+  shortTerm: string | null;
+  midTerm: string | null;
+  longTerm: string | null;
+}
+
+export interface FeedbackCard {
+  date: string;
+  completedTodos: string[];
+  incompleteTodos: string[];
+  coachComment?: string;
+  userNote?: string;
+  userEdited?: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface NotificationSettings {
+  morningEnabled: boolean;
+  morningTime: string;
+  eveningEnabled: boolean;
+  eveningTime: string;
+  timezone?: string;
+  notificationPermission: 'granted' | 'denied' | 'default';
+  fcmToken?: string;
+  lastMorningSentDate?: string;
+  lastEveningSentDate?: string;
+  updatedAt: number;
+}
+
+export interface GoalAdjustment {
+  goalId: string;
+  goalText: string;
+  currentMetric: string;
+  suggestedMetric: string;
+  reason: string;
+  avgCompletion: number;
+  weeks: number;
+  status: 'pending' | 'accepted' | 'dismissed';
+}

--- a/supercoach-ai-native/tailwind.config.js
+++ b/supercoach-ai-native/tailwind.config.js
@@ -1,0 +1,19 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./app/**/*.{js,jsx,ts,tsx}",
+    "./components/**/*.{js,jsx,ts,tsx}",
+    "./shared/**/*.{js,jsx,ts,tsx}",
+  ],
+  presets: [require("nativewind/preset")],
+  theme: {
+    extend: {
+      colors: {
+        accent: "#71B7FF",
+        surface: "#1A1F2E",
+        background: "#0A0E1A",
+      },
+    },
+  },
+  plugins: [],
+};

--- a/supercoach-ai-native/tsconfig.json
+++ b/supercoach-ai-native/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".expo/types/**/*.ts",
+    "expo-env.d.ts",
+    "nativewind-env.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- Converts the web ToDoList component to React Native using DraggableFlatList for drag-to-reorder
- Adds TodoItem component with animated checkbox (reanimated), priority indicators, due date/repeat/goal badges, and drag handle
- Adds TodoEditModal (full-screen modal) for creating/editing tasks with priority picker, quick date buttons, repeat selector, goal linking, tags, and notes
- Adds TodoFilters with horizontal scroll filter chips (All/Pending/Done) and sort dropdown (Date/Priority/Created)
- Includes quick-add bar, search toggle, and floating action button
- Extracts shared repeat-label constants to avoid duplication between components

## Test plan
- [ ] Verify the todo screen renders with sample data
- [ ] Test drag-to-reorder on todo items
- [ ] Test toggling todo completion (animated checkbox)
- [ ] Test creating a new todo via FAB and quick-add bar
- [ ] Test editing an existing todo via the modal
- [ ] Test filter chips switch between All/Pending/Done
- [ ] Test sort dropdown changes ordering
- [ ] Test search filters tasks by text/tags/notes
- [ ] Test delete flow with confirmation alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)