### PR TITLE
feat: add mind map screen with custom SVG rendering (Unit 6)

### DIFF
--- a/supercoach-ai-native/app/(tabs)/goals.tsx
+++ b/supercoach-ai-native/app/(tabs)/goals.tsx
@@ -1,0 +1,243 @@
+import React, { useState, useCallback } from 'react';
+import { View, Text, TouchableOpacity, Alert, TextInput } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Plus } from 'lucide-react-native';
+import { MindMapCanvas } from '../../components/mindmap/MindMapCanvas';
+import { MindMapControls } from '../../components/mindmap/MindMapControls';
+import type { GoalNode, GoalLink } from '../../shared/types';
+import { NodeType, NodeStatus } from '../../shared/types';
+import { getLinkId } from '../../hooks/useAutoSave';
+
+const INITIAL_NODES: GoalNode[] = [
+  {
+    id: 'root',
+    text: 'My Goals',
+    type: NodeType.ROOT,
+    status: NodeStatus.PENDING,
+    progress: 0,
+  },
+];
+
+const INITIAL_LINKS: GoalLink[] = [];
+
+function generateId(): string {
+  return `node_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createSubNode(parentId: string): { node: GoalNode; link: GoalLink } {
+  const newId = generateId();
+  return {
+    node: {
+      id: newId,
+      text: 'New Goal',
+      type: NodeType.SUB,
+      status: NodeStatus.PENDING,
+      progress: 0,
+      parentId,
+    },
+    link: { source: parentId, target: newId },
+  };
+}
+
+export default function GoalsScreen() {
+  const [nodes, setNodes] = useState<GoalNode[]>(INITIAL_NODES);
+  const [links, setLinks] = useState<GoalLink[]>(INITIAL_LINKS);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [editingNodeId, setEditingNodeId] = useState<string | null>(null);
+  const [editText, setEditText] = useState('');
+
+  const selectedNode = nodes.find((n) => n.id === selectedNodeId) ?? null;
+
+  const addNodeUnder = useCallback((parentId: string) => {
+    const { node, link } = createSubNode(parentId);
+    setNodes((prev) => [...prev, node]);
+    setLinks((prev) => [...prev, link]);
+    setSelectedNodeId(node.id);
+    setEditingNodeId(node.id);
+    setEditText('New Goal');
+  }, []);
+
+  const handleNodePress = useCallback((nodeId: string) => {
+    setSelectedNodeId((prev) => (prev === nodeId ? null : nodeId));
+  }, []);
+
+  const handleNodeLongPress = useCallback(
+    (nodeId: string) => {
+      const node = nodes.find((n) => n.id === nodeId);
+      if (!node) return;
+      setEditingNodeId(nodeId);
+      setEditText(node.text);
+    },
+    [nodes],
+  );
+
+  const handleAddChild = useCallback(() => {
+    if (!selectedNodeId) return;
+    addNodeUnder(selectedNodeId);
+  }, [selectedNodeId, addNodeUnder]);
+
+  const handleAddSibling = useCallback(() => {
+    if (!selectedNodeId) return;
+    const parentLink = links.find(
+      (l) => getLinkId(l.target) === selectedNodeId,
+    );
+    if (!parentLink) return;
+    addNodeUnder(getLinkId(parentLink.source));
+  }, [selectedNodeId, links, addNodeUnder]);
+
+  const handleEdit = useCallback(() => {
+    if (!selectedNodeId) return;
+    const node = nodes.find((n) => n.id === selectedNodeId);
+    if (!node) return;
+    setEditingNodeId(selectedNodeId);
+    setEditText(node.text);
+  }, [selectedNodeId, nodes]);
+
+  const handleEditSubmit = useCallback(() => {
+    if (!editingNodeId || !editText.trim()) {
+      setEditingNodeId(null);
+      return;
+    }
+    setNodes((prev) =>
+      prev.map((n) =>
+        n.id === editingNodeId ? { ...n, text: editText.trim() } : n,
+      ),
+    );
+    setEditingNodeId(null);
+    setEditText('');
+  }, [editingNodeId, editText]);
+
+  const handleDelete = useCallback(() => {
+    if (!selectedNodeId) return;
+    const node = nodes.find((n) => n.id === selectedNodeId);
+    if (!node || node.type === NodeType.ROOT) return;
+
+    Alert.alert('Delete Node', `Delete "${node.text}" and all its children?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: () => {
+          const toDelete = new Set<string>();
+          const queue = [selectedNodeId];
+          while (queue.length > 0) {
+            const id = queue.pop()!;
+            toDelete.add(id);
+            for (const link of links) {
+              const sourceId = getLinkId(link.source);
+              const targetId = getLinkId(link.target);
+              if (sourceId === id && !toDelete.has(targetId)) {
+                queue.push(targetId);
+              }
+            }
+          }
+          setNodes((prev) => prev.filter((n) => !toDelete.has(n.id)));
+          setLinks((prev) =>
+            prev.filter((l) => {
+              const s = getLinkId(l.source);
+              const t = getLinkId(l.target);
+              return !toDelete.has(s) && !toDelete.has(t);
+            }),
+          );
+          setSelectedNodeId(null);
+        },
+      },
+    ]);
+  }, [selectedNodeId, nodes, links]);
+
+  const handleToggleComplete = useCallback(() => {
+    if (!selectedNodeId) return;
+    setNodes((prev) =>
+      prev.map((n) =>
+        n.id === selectedNodeId
+          ? {
+              ...n,
+              status:
+                n.status === NodeStatus.COMPLETED
+                  ? NodeStatus.PENDING
+                  : NodeStatus.COMPLETED,
+            }
+          : n,
+      ),
+    );
+  }, [selectedNodeId]);
+
+  const handleCreateTodo = useCallback(() => {
+    if (!selectedNode) return;
+    Alert.alert('Create Todo', `Todo created from "${selectedNode.text}"`);
+  }, [selectedNode]);
+
+  const handleGenerateImage = useCallback(() => {
+    if (!selectedNode) return;
+    Alert.alert('Generate Image', `AI image generation for "${selectedNode.text}"`);
+  }, [selectedNode]);
+
+  const handleDecompose = useCallback(() => {
+    if (!selectedNode) return;
+    Alert.alert('Decompose', `AI decomposition for "${selectedNode.text}"`);
+  }, [selectedNode]);
+
+  const handleAddRootChild = useCallback(() => {
+    const rootNode = nodes.find((n) => n.type === NodeType.ROOT);
+    if (!rootNode) return;
+    addNodeUnder(rootNode.id);
+  }, [nodes, addNodeUnder]);
+
+  return (
+    <SafeAreaView className="flex-1 bg-slate-900" edges={['top']}>
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-2 border-b border-slate-700/50">
+        <Text className="text-lg font-bold text-white">Goals</Text>
+        <TouchableOpacity
+          onPress={handleAddRootChild}
+          className="w-9 h-9 rounded-full bg-blue-500/20 items-center justify-center"
+          activeOpacity={0.7}
+        >
+          <Plus size={20} color="#5AA9FF" />
+        </TouchableOpacity>
+      </View>
+
+      {/* Inline edit input */}
+      {editingNodeId && (
+        <View className="absolute top-16 left-4 right-4 z-50 bg-slate-800 rounded-xl px-4 py-3 border border-slate-600">
+          <Text className="text-slate-400 text-xs mb-1">Edit node name</Text>
+          <TextInput
+            value={editText}
+            onChangeText={setEditText}
+            onSubmitEditing={handleEditSubmit}
+            onBlur={handleEditSubmit}
+            autoFocus
+            className="text-white text-base bg-slate-700 rounded-lg px-3 py-2"
+            placeholderTextColor="#64748b"
+            returnKeyType="done"
+          />
+        </View>
+      )}
+
+      {/* Canvas */}
+      <View className="flex-1">
+        <MindMapCanvas
+          nodes={nodes}
+          links={links}
+          selectedNodeId={selectedNodeId}
+          onNodePress={handleNodePress}
+          onNodeLongPress={handleNodeLongPress}
+        />
+      </View>
+
+      {/* Controls bar */}
+      <MindMapControls
+        visible={selectedNodeId !== null}
+        onAddChild={handleAddChild}
+        onAddSibling={handleAddSibling}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        onToggleComplete={handleToggleComplete}
+        onCreateTodo={handleCreateTodo}
+        onGenerateImage={handleGenerateImage}
+        onDecompose={handleDecompose}
+        isRoot={selectedNode?.type === NodeType.ROOT}
+      />
+    </SafeAreaView>
+  );
+}

--- a/supercoach-ai-native/app/coach-chat.tsx
+++ b/supercoach-ai-native/app/coach-chat.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { useTranslation } from '../shared/i18n/useTranslation';
+
+export default function CoachChatScreen() {
+  const { t } = useTranslation();
+
+  return (
+    <View className="flex-1 items-center justify-center bg-background">
+      <Text className="text-white text-xl font-bold">{t.coach.title}</Text>
+    </View>
+  );
+}

--- a/supercoach-ai-native/components/CoachBubble.tsx
+++ b/supercoach-ai-native/components/CoachBubble.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Pressable, View } from 'react-native';
+import { MessageCircle } from 'lucide-react-native';
+import { useRouter } from 'expo-router';
+
+interface CoachBubbleProps {
+  hasUnread?: boolean;
+}
+
+const CoachBubble: React.FC<CoachBubbleProps> = ({ hasUnread = false }) => {
+  const router = useRouter();
+
+  return (
+    <Pressable
+      onPress={() => router.push('/coach-chat')}
+      className="absolute bottom-24 right-5 z-50 w-14 h-14 rounded-full bg-blue-500 items-center justify-center shadow-lg"
+      style={{ elevation: 8 }}
+    >
+      <MessageCircle size={26} color="#fff" />
+      {hasUnread && (
+        <View className="absolute top-0 right-0 w-3.5 h-3.5 rounded-full bg-red-500 border-2 border-white" />
+      )}
+    </Pressable>
+  );
+};
+
+export default CoachBubble;

--- a/supercoach-ai-native/components/mindmap/MindMapCanvas.tsx
+++ b/supercoach-ai-native/components/mindmap/MindMapCanvas.tsx
@@ -1,0 +1,165 @@
+import React, { useCallback, useMemo } from 'react';
+import { useWindowDimensions } from 'react-native';
+import Svg, { G } from 'react-native-svg';
+import { GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+import type { GoalNode, GoalLink } from '../../shared/types';
+import { NodeStatus } from '../../shared/types';
+import { getLinkId } from '../../hooks/useAutoSave';
+import { useMindMapLayout } from './useMindMapLayout';
+import { useMindMapGestures } from './useMindMapGestures';
+import { MindMapNode, getStatusColor } from './MindMapNode';
+import { MindMapEdge } from './MindMapEdge';
+
+interface MindMapCanvasProps {
+  nodes: GoalNode[];
+  links: GoalLink[];
+  selectedNodeId: string | null;
+  onNodePress: (nodeId: string) => void;
+  onNodeLongPress: (nodeId: string) => void;
+}
+
+/** Build a map of parentId -> childIds from links (once per render). */
+function buildChildrenMap(links: GoalLink[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const link of links) {
+    const sourceId = getLinkId(link.source);
+    const targetId = getLinkId(link.target);
+    if (!map.has(sourceId)) map.set(sourceId, []);
+    map.get(sourceId)!.push(targetId);
+  }
+  return map;
+}
+
+/** Compute completion progress for a node based on its direct children. */
+function computeProgress(
+  nodeId: string,
+  childrenMap: Map<string, string[]>,
+  nodeMap: Map<string, GoalNode>,
+): number | undefined {
+  const childIds = childrenMap.get(nodeId);
+  if (!childIds || childIds.length === 0) return undefined;
+  const completed = childIds.filter((id) => {
+    const n = nodeMap.get(id);
+    return n?.status === NodeStatus.COMPLETED;
+  }).length;
+  return Math.round((completed / childIds.length) * 100);
+}
+
+export const MindMapCanvas: React.FC<MindMapCanvasProps> = ({
+  nodes,
+  links,
+  selectedNodeId,
+  onNodePress,
+  onNodeLongPress,
+}) => {
+  const { width: screenWidth, height: screenHeight } = useWindowDimensions();
+  const layout = useMindMapLayout(nodes, links);
+  const { gesture, translateX, translateY, scale } = useMindMapGestures();
+
+  const nodeMap = useMemo(
+    () => new Map(nodes.map((n) => [n.id, n])),
+    [nodes],
+  );
+
+  const childrenMap = useMemo(() => buildChildrenMap(links), [links]);
+
+  // Compute SVG canvas size from layout
+  const canvasSize = useMemo(() => {
+    let maxX = screenWidth;
+    let maxY = screenHeight;
+    for (const pos of layout.values()) {
+      maxX = Math.max(maxX, pos.x + pos.width + 100);
+      maxY = Math.max(maxY, pos.y + pos.height + 100);
+    }
+    return { width: maxX, height: maxY };
+  }, [layout, screenWidth, screenHeight]);
+
+  // Build edges from links
+  const edges = useMemo(() => {
+    const result: Array<{
+      key: string;
+      parentLayout: { x: number; y: number; width: number; height: number };
+      childLayout: { x: number; y: number; width: number; height: number };
+      color: string;
+    }> = [];
+
+    for (const link of links) {
+      const sourceId = getLinkId(link.source);
+      const targetId = getLinkId(link.target);
+      const parentPos = layout.get(sourceId);
+      const childPos = layout.get(targetId);
+      const parentNode = nodeMap.get(sourceId);
+      if (!parentPos || !childPos || !parentNode) continue;
+
+      result.push({
+        key: `${sourceId}-${targetId}`,
+        parentLayout: parentPos,
+        childLayout: childPos,
+        color: getStatusColor(parentNode.status),
+      });
+    }
+    return result;
+  }, [links, layout, nodeMap]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translateX.value },
+      { translateY: translateY.value },
+      { scale: scale.value },
+    ],
+  }));
+
+  const handleNodePress = useCallback(
+    (nodeId: string) => onNodePress(nodeId),
+    [onNodePress],
+  );
+
+  const handleNodeLongPress = useCallback(
+    (nodeId: string) => onNodeLongPress(nodeId),
+    [onNodeLongPress],
+  );
+
+  return (
+    <GestureDetector gesture={gesture}>
+      <Animated.View style={[{ flex: 1 }, animatedStyle]}>
+        <Svg
+          width={canvasSize.width}
+          height={canvasSize.height}
+          viewBox={`0 0 ${canvasSize.width} ${canvasSize.height}`}
+        >
+          <G>
+            {/* Edges first (behind nodes) */}
+            {edges.map((edge) => (
+              <MindMapEdge
+                key={edge.key}
+                parentLayout={edge.parentLayout}
+                childLayout={edge.childLayout}
+                color={edge.color}
+              />
+            ))}
+
+            {/* Nodes */}
+            {nodes.map((node) => {
+              const pos = layout.get(node.id);
+              if (!pos) return null;
+              return (
+                <MindMapNode
+                  key={node.id}
+                  node={node}
+                  layout={pos}
+                  isSelected={node.id === selectedNodeId}
+                  onPress={handleNodePress}
+                  onLongPress={handleNodeLongPress}
+                  progress={computeProgress(node.id, childrenMap, nodeMap)}
+                />
+              );
+            })}
+          </G>
+        </Svg>
+      </Animated.View>
+    </GestureDetector>
+  );
+};

--- a/supercoach-ai-native/components/mindmap/MindMapControls.tsx
+++ b/supercoach-ai-native/components/mindmap/MindMapControls.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { View, TouchableOpacity } from 'react-native';
+import {
+  Plus,
+  GitBranch,
+  Pencil,
+  Trash2,
+  CheckCircle,
+  CheckSquare,
+  ImageIcon,
+} from 'lucide-react-native';
+
+interface MindMapControlsProps {
+  visible: boolean;
+  onAddChild: () => void;
+  onAddSibling: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggleComplete: () => void;
+  onCreateTodo: () => void;
+  onGenerateImage: () => void;
+  onDecompose: () => void;
+  isRoot?: boolean;
+}
+
+interface ActionButtonProps {
+  icon: React.ReactNode;
+  onPress: () => void;
+  color?: string;
+}
+
+const ActionButton: React.FC<ActionButtonProps> = ({ icon, onPress, color }) => (
+  <TouchableOpacity
+    onPress={onPress}
+    className="w-9 h-9 rounded-full items-center justify-center mx-0.5"
+    style={{ backgroundColor: color ?? 'rgba(255,255,255,0.12)' }}
+    activeOpacity={0.7}
+  >
+    {icon}
+  </TouchableOpacity>
+);
+
+export const MindMapControls: React.FC<MindMapControlsProps> = ({
+  visible,
+  onAddChild,
+  onAddSibling,
+  onEdit,
+  onDelete,
+  onToggleComplete,
+  onCreateTodo,
+  onGenerateImage,
+  onDecompose,
+  isRoot,
+}) => {
+  if (!visible) return null;
+
+  const iconSize = 18;
+  const iconColor = '#F8FBFF';
+
+  return (
+    <View
+      className="absolute bottom-0 left-0 right-0 flex-row items-center justify-center py-2 px-3"
+      style={{
+        backgroundColor: 'rgba(15, 23, 42, 0.92)',
+        borderTopWidth: 1,
+        borderTopColor: 'rgba(255,255,255,0.1)',
+      }}
+    >
+      <ActionButton
+        icon={<Plus size={iconSize} color={iconColor} />}
+        onPress={onAddChild}
+      />
+      {!isRoot && (
+        <ActionButton
+          icon={<GitBranch size={iconSize} color={iconColor} />}
+          onPress={onAddSibling}
+        />
+      )}
+      <ActionButton
+        icon={<Pencil size={iconSize} color={iconColor} />}
+        onPress={onEdit}
+      />
+      <ActionButton
+        icon={<CheckCircle size={iconSize} color="#4DE8E0" />}
+        onPress={onToggleComplete}
+      />
+      <ActionButton
+        icon={<CheckSquare size={iconSize} color={iconColor} />}
+        onPress={onCreateTodo}
+      />
+      <ActionButton
+        icon={<ImageIcon size={iconSize} color={iconColor} />}
+        onPress={onGenerateImage}
+      />
+      <ActionButton
+        icon={
+          <GitBranch
+            size={iconSize}
+            color={iconColor}
+            style={{ transform: [{ rotate: '180deg' }] }}
+          />
+        }
+        onPress={onDecompose}
+      />
+      {!isRoot && (
+        <ActionButton
+          icon={<Trash2 size={iconSize} color="#FF7B72" />}
+          onPress={onDelete}
+          color="rgba(255, 123, 114, 0.15)"
+        />
+      )}
+    </View>
+  );
+};

--- a/supercoach-ai-native/components/mindmap/MindMapEdge.tsx
+++ b/supercoach-ai-native/components/mindmap/MindMapEdge.tsx
@@ -1,0 +1,44 @@
+import React, { memo } from 'react';
+import { Path } from 'react-native-svg';
+import type { LayoutNode } from './useMindMapLayout';
+
+interface MindMapEdgeProps {
+  parentLayout: LayoutNode;
+  childLayout: LayoutNode;
+  color: string;
+}
+
+const MindMapEdgeComponent: React.FC<MindMapEdgeProps> = ({
+  parentLayout,
+  childLayout,
+  color,
+}) => {
+  // Start from bottom-center of parent
+  const x1 = parentLayout.x + parentLayout.width / 2;
+  const y1 = parentLayout.y + parentLayout.height;
+
+  // End at top-center of child
+  const x2 = childLayout.x + childLayout.width / 2;
+  const y2 = childLayout.y;
+
+  // Cubic bezier control points for smooth curve
+  const midY = (y1 + y2) / 2;
+  const cp1x = x1;
+  const cp1y = midY;
+  const cp2x = x2;
+  const cp2y = midY;
+
+  const d = `M ${x1} ${y1} C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${x2} ${y2}`;
+
+  return (
+    <Path
+      d={d}
+      stroke={color}
+      strokeWidth={2}
+      fill="none"
+      opacity={0.7}
+    />
+  );
+};
+
+export const MindMapEdge = memo(MindMapEdgeComponent);

--- a/supercoach-ai-native/components/mindmap/MindMapNode.tsx
+++ b/supercoach-ai-native/components/mindmap/MindMapNode.tsx
@@ -1,0 +1,136 @@
+import React, { memo, useCallback } from 'react';
+import { G, Rect, Text as SvgText } from 'react-native-svg';
+import type { GoalNode } from '../../shared/types';
+import { NodeStatus } from '../../shared/types';
+import type { LayoutNode } from './useMindMapLayout';
+
+const STATUS_COLORS: Record<NodeStatus, string> = {
+  [NodeStatus.PENDING]: '#5AA9FF',
+  [NodeStatus.COMPLETED]: '#4DE8E0',
+  [NodeStatus.STUCK]: '#FF7B72',
+};
+
+// IN_PROGRESS is not in the enum but referenced in spec as yellow
+const IN_PROGRESS_COLOR = '#FFD166';
+
+function getStatusColor(status: NodeStatus | string): string {
+  if (status === 'IN_PROGRESS') return IN_PROGRESS_COLOR;
+  return STATUS_COLORS[status as NodeStatus] ?? STATUS_COLORS[NodeStatus.PENDING];
+}
+
+interface MindMapNodeProps {
+  node: GoalNode;
+  layout: LayoutNode;
+  isSelected: boolean;
+  onPress: (nodeId: string) => void;
+  onLongPress: (nodeId: string) => void;
+  progress?: number;
+}
+
+function truncateText(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen - 1) + '\u2026';
+}
+
+const MindMapNodeComponent: React.FC<MindMapNodeProps> = ({
+  node,
+  layout,
+  isSelected,
+  onPress,
+  onLongPress,
+  progress,
+}) => {
+  const borderColor = getStatusColor(node.status);
+  const fillColor = node.status === NodeStatus.COMPLETED
+    ? 'rgba(17, 89, 94, 0.9)'
+    : node.status === NodeStatus.STUCK
+      ? 'rgba(96, 28, 38, 0.9)'
+      : 'rgba(24, 52, 92, 0.9)';
+  const textColor = '#F8FBFF';
+
+  const handlePress = useCallback(() => {
+    onPress(node.id);
+  }, [onPress, node.id]);
+
+  const handleLongPress = useCallback(() => {
+    onLongPress(node.id);
+  }, [onLongPress, node.id]);
+
+  const displayText = truncateText(node.text, 18);
+  const showProgress = progress !== undefined && progress > 0 && progress < 100;
+
+  return (
+    <G
+      x={layout.x}
+      y={layout.y}
+      onPress={handlePress}
+      onLongPress={handleLongPress}
+    >
+      {/* Selection highlight */}
+      {isSelected && (
+        <Rect
+          x={-3}
+          y={-3}
+          width={layout.width + 6}
+          height={layout.height + 6}
+          rx={12}
+          fill="none"
+          stroke="#FFFFFF"
+          strokeWidth={2}
+          strokeDasharray="6,3"
+          opacity={0.6}
+        />
+      )}
+
+      {/* Node background */}
+      <Rect
+        x={0}
+        y={0}
+        width={layout.width}
+        height={layout.height}
+        rx={10}
+        fill={fillColor}
+        stroke={borderColor}
+        strokeWidth={isSelected ? 2.5 : 1.5}
+      />
+
+      {/* Progress bar background */}
+      {showProgress && (
+        <>
+          <Rect
+            x={4}
+            y={layout.height - 8}
+            width={layout.width - 8}
+            height={4}
+            rx={2}
+            fill="rgba(255,255,255,0.15)"
+          />
+          <Rect
+            x={4}
+            y={layout.height - 8}
+            width={(layout.width - 8) * (progress / 100)}
+            height={4}
+            rx={2}
+            fill={borderColor}
+          />
+        </>
+      )}
+
+      {/* Node text */}
+      <SvgText
+        x={layout.width / 2}
+        y={showProgress ? layout.height / 2 - 2 : layout.height / 2 + 1}
+        textAnchor="middle"
+        alignmentBaseline="central"
+        fill={textColor}
+        fontSize={13}
+        fontWeight={node.type === 'ROOT' ? '700' : '500'}
+      >
+        {displayText}
+      </SvgText>
+    </G>
+  );
+};
+
+export const MindMapNode = memo(MindMapNodeComponent);
+export { getStatusColor };

--- a/supercoach-ai-native/components/mindmap/useMindMapGestures.ts
+++ b/supercoach-ai-native/components/mindmap/useMindMapGestures.ts
@@ -1,0 +1,69 @@
+import { useCallback } from 'react';
+import { Gesture } from 'react-native-gesture-handler';
+import {
+  useSharedValue,
+  withDecay,
+} from 'react-native-reanimated';
+
+export function useMindMapGestures() {
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const scale = useSharedValue(1);
+
+  // Saved values for gesture continuity
+  const savedTranslateX = useSharedValue(0);
+  const savedTranslateY = useSharedValue(0);
+  const savedScale = useSharedValue(1);
+
+  const panGesture = Gesture.Pan()
+    .onStart(() => {
+      'worklet';
+      savedTranslateX.value = translateX.value;
+      savedTranslateY.value = translateY.value;
+    })
+    .onUpdate((event) => {
+      'worklet';
+      translateX.value = savedTranslateX.value + event.translationX;
+      translateY.value = savedTranslateY.value + event.translationY;
+    })
+    .onEnd((event) => {
+      'worklet';
+      translateX.value = withDecay({
+        velocity: event.velocityX,
+        deceleration: 0.997,
+      });
+      translateY.value = withDecay({
+        velocity: event.velocityY,
+        deceleration: 0.997,
+      });
+    })
+    .minPointers(1)
+    .maxPointers(2);
+
+  const pinchGesture = Gesture.Pinch()
+    .onStart(() => {
+      'worklet';
+      savedScale.value = scale.value;
+    })
+    .onUpdate((event) => {
+      'worklet';
+      const newScale = savedScale.value * event.scale;
+      scale.value = Math.max(0.3, Math.min(3, newScale));
+    });
+
+  const composed = Gesture.Simultaneous(panGesture, pinchGesture);
+
+  const resetTransform = useCallback(() => {
+    translateX.value = 0;
+    translateY.value = 0;
+    scale.value = 1;
+  }, [translateX, translateY, scale]);
+
+  return {
+    gesture: composed,
+    translateX,
+    translateY,
+    scale,
+    resetTransform,
+  };
+}

--- a/supercoach-ai-native/components/mindmap/useMindMapLayout.ts
+++ b/supercoach-ai-native/components/mindmap/useMindMapLayout.ts
@@ -1,0 +1,188 @@
+import { useMemo } from 'react';
+import type { GoalNode, GoalLink } from '../../shared/types';
+import { getLinkId } from '../../hooks/useAutoSave';
+
+export interface LayoutNode {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const NODE_WIDTH = 160;
+const NODE_HEIGHT = 50;
+const H_SPACING = 40;
+const V_SPACING = 60;
+
+interface TreeNode {
+  id: string;
+  children: TreeNode[];
+  // layout intermediates
+  x: number;
+  y: number;
+  modifier: number;
+  depth: number;
+}
+
+function buildTree(
+  nodes: GoalNode[],
+  links: GoalLink[],
+): TreeNode | null {
+  if (nodes.length === 0) return null;
+
+  const childrenMap = new Map<string, string[]>();
+  const hasParent = new Set<string>();
+
+  for (const link of links) {
+    const sourceId = getLinkId(link.source);
+    const targetId = getLinkId(link.target);
+    if (!childrenMap.has(sourceId)) childrenMap.set(sourceId, []);
+    childrenMap.get(sourceId)!.push(targetId);
+    hasParent.add(targetId);
+  }
+
+  // Find root: node with type ROOT, or node without parent
+  const nodeMap = new Map(nodes.map((n) => [n.id, n]));
+  let rootId = nodes.find((n) => n.type === 'ROOT')?.id;
+  if (!rootId) {
+    rootId = nodes.find((n) => !hasParent.has(n.id))?.id;
+  }
+  if (!rootId) rootId = nodes[0].id;
+
+  function build(id: string, depth: number): TreeNode | null {
+    if (!nodeMap.has(id)) return null;
+    const childIds = childrenMap.get(id) ?? [];
+    const children: TreeNode[] = [];
+    for (const cid of childIds) {
+      const child = build(cid, depth + 1);
+      if (child) children.push(child);
+    }
+    return { id, children, x: 0, y: 0, modifier: 0, depth };
+  }
+
+  return build(rootId, 0);
+}
+
+function layoutTree(node: TreeNode, siblingIndex: number): void {
+  // Post-order: layout children first
+  for (let i = 0; i < node.children.length; i++) {
+    layoutTree(node.children[i], i);
+  }
+
+  node.y = node.depth * (NODE_HEIGHT + V_SPACING);
+
+  if (node.children.length === 0) {
+    node.x = 0;
+  } else if (node.children.length === 1) {
+    node.x = node.children[0].x;
+  } else {
+    const first = node.children[0].x;
+    const last = node.children[node.children.length - 1].x;
+    node.x = (first + last) / 2;
+  }
+}
+
+function assignSiblingPositions(node: TreeNode): void {
+  // Space siblings so they don't overlap
+  for (let i = 1; i < node.children.length; i++) {
+    const prev = node.children[i - 1];
+    const curr = node.children[i];
+    const minX = getMaxXInSubtree(prev) + NODE_WIDTH + H_SPACING;
+    const currMinX = getMinXInSubtree(curr);
+    if (currMinX < minX) {
+      const shift = minX - currMinX;
+      shiftSubtree(curr, shift);
+    }
+  }
+
+  // Recenter parent over children
+  if (node.children.length > 0) {
+    const first = node.children[0].x;
+    const last = node.children[node.children.length - 1].x;
+    const mid = (first + last) / 2;
+    // Don't shift root if it creates negative positions
+    node.x = mid;
+  }
+
+  for (const child of node.children) {
+    assignSiblingPositions(child);
+  }
+}
+
+function getMinXInSubtree(node: TreeNode): number {
+  let min = node.x;
+  for (const child of node.children) {
+    min = Math.min(min, getMinXInSubtree(child));
+  }
+  return min;
+}
+
+function getMaxXInSubtree(node: TreeNode): number {
+  let max = node.x;
+  for (const child of node.children) {
+    max = Math.max(max, getMaxXInSubtree(child));
+  }
+  return max;
+}
+
+function shiftSubtree(node: TreeNode, shift: number): void {
+  node.x += shift;
+  for (const child of node.children) {
+    shiftSubtree(child, shift);
+  }
+}
+
+function collectPositions(node: TreeNode, result: Map<string, LayoutNode>): void {
+  result.set(node.id, {
+    id: node.id,
+    x: node.x,
+    y: node.y,
+    width: NODE_WIDTH,
+    height: NODE_HEIGHT,
+  });
+  for (const child of node.children) {
+    collectPositions(child, result);
+  }
+}
+
+function normalizePositions(positions: Map<string, LayoutNode>): void {
+  let minX = Infinity;
+  let minY = Infinity;
+  for (const pos of positions.values()) {
+    minX = Math.min(minX, pos.x);
+    minY = Math.min(minY, pos.y);
+  }
+  const offsetX = -minX + 40;
+  const offsetY = -minY + 40;
+  for (const pos of positions.values()) {
+    pos.x += offsetX;
+    pos.y += offsetY;
+  }
+}
+
+export function computeLayout(
+  nodes: GoalNode[],
+  links: GoalLink[],
+): Map<string, LayoutNode> {
+  const root = buildTree(nodes, links);
+  if (!root) return new Map();
+
+  layoutTree(root, 0);
+  assignSiblingPositions(root);
+
+  const positions = new Map<string, LayoutNode>();
+  collectPositions(root, positions);
+  normalizePositions(positions);
+
+  return positions;
+}
+
+export function useMindMapLayout(
+  nodes: GoalNode[],
+  links: GoalLink[],
+): Map<string, LayoutNode> {
+  return useMemo(() => computeLayout(nodes, links), [nodes, links]);
+}
+
+export { NODE_WIDTH, NODE_HEIGHT };

--- a/supercoach-ai-native/hooks/useCoachFeedback.ts
+++ b/supercoach-ai-native/hooks/useCoachFeedback.ts
@@ -1,0 +1,146 @@
+import { useState, useEffect, useCallback } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { ToDoItem } from '../shared/types';
+import type { AppLanguage } from '../shared/i18nTypes';
+
+const todayKey = (): string => {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+};
+
+const STORAGE_PREFIX = 'secretcoach-feedback-done';
+
+const wasDone = async (slot: 'morning' | 'evening'): Promise<boolean> => {
+  try {
+    const val = await AsyncStorage.getItem(`${STORAGE_PREFIX}-${todayKey()}-${slot}`);
+    return val === '1';
+  } catch {
+    return false;
+  }
+};
+
+const markDone = async (slot: 'morning' | 'evening'): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(`${STORAGE_PREFIX}-${todayKey()}-${slot}`, '1');
+  } catch {
+    // ignore
+  }
+};
+
+const getMorningDirective = (lang: AppLanguage): string =>
+  lang === 'ko'
+    ? `[아침 피드백 모드]
+지금은 하루 시작 브리핑 시간입니다.
+오늘 예정 할일을 먼저 짧게 정리하고 칭찬을 1문장 포함하세요.
+그 다음 질문은 딱 2개만 하세요.
+1) 오늘 일정/할일에서 조정할 것이 있는지
+2) 오늘 새로 추가할 할일이 있는지
+문장은 짧고 따뜻하게 유지하세요.`
+    : `[Morning Feedback Mode]
+This is the start-of-day briefing.
+Summarize today's planned tasks first and include one short praise sentence.
+Then ask exactly two questions:
+1) Any adjustments needed for today's schedule or tasks?
+2) Any extra tasks to add for today?
+Keep it concise and warm.`;
+
+const buildEveningDirective = (
+  completed: string[],
+  incomplete: string[],
+  lang: AppLanguage,
+): string => {
+  if (lang === 'ko') {
+    return `[저녁 피드백 모드 - 오늘의 승리]
+완료한 할일: ${completed.length > 0 ? completed.join(', ') : '없음'}
+미완료 할일: ${incomplete.length > 0 ? incomplete.join(', ') : '없음'}
+
+대화 순서:
+1) 완료한 항목을 먼저 칭찬
+2) 미완료 항목의 이유/사정을 부드럽게 질문
+3) 필요하면 내일 계획 조정 제안
+
+대화가 마무리되는 마지막 응답 끝에 아래 형식을 추가하세요.
+<!-- COMMENT: 오늘의 승리 한줄 요약 -->`;
+  }
+
+  return `[Evening Feedback Mode - Today's Wins]
+Completed todos: ${completed.length > 0 ? completed.join(', ') : 'None'}
+Incomplete todos: ${incomplete.length > 0 ? incomplete.join(', ') : 'None'}
+
+Conversation order:
+1) Praise completed items first
+2) Gently ask reasons for incomplete items
+3) Suggest plan adjustment for tomorrow if needed
+
+When wrapping up, append:
+<!-- COMMENT: one-line summary of today's win -->`;
+};
+
+export type FeedbackSlot = 'morning' | 'evening' | null;
+
+interface CoachFeedbackResult {
+  pendingDirective: string | null;
+  feedbackSlot: FeedbackSlot;
+  markFeedbackDone: () => void;
+}
+
+export const useCoachFeedback = (
+  isOpen: boolean,
+  todos: ToDoItem[],
+  language: AppLanguage = 'ko',
+  forcedSlot: FeedbackSlot = null,
+): CoachFeedbackResult => {
+  const [pendingDirective, setPendingDirective] = useState<string | null>(null);
+  const [feedbackSlot, setFeedbackSlot] = useState<FeedbackSlot>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setPendingDirective(null);
+      setFeedbackSlot(null);
+      return;
+    }
+    if (pendingDirective) return;
+
+    if (!forcedSlot) {
+      setFeedbackSlot(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const check = async () => {
+      const done = await wasDone(forcedSlot);
+      if (cancelled || done) {
+        if (!cancelled) setFeedbackSlot(null);
+        return;
+      }
+
+      if (forcedSlot === 'morning') {
+        setPendingDirective(getMorningDirective(language));
+        setFeedbackSlot('morning');
+        return;
+      }
+
+      const completed = todos.filter((t) => t.completed).map((t) => t.text);
+      const incomplete = todos.filter((t) => !t.completed).map((t) => t.text);
+      setPendingDirective(buildEveningDirective(completed, incomplete, language));
+      setFeedbackSlot('evening');
+    };
+
+    check();
+
+    return () => { cancelled = true; };
+  }, [isOpen, todos, language, forcedSlot, pendingDirective]);
+
+  const markFeedbackDone = useCallback(() => {
+    if (!feedbackSlot) return;
+    markDone(feedbackSlot);
+    setPendingDirective(null);
+    setFeedbackSlot(null);
+  }, [feedbackSlot]);
+
+  return { pendingDirective, feedbackSlot, markFeedbackDone };
+};

--- a/supercoach-ai-native/hooks/useCoachMemory.ts
+++ b/supercoach-ai-native/hooks/useCoachMemory.ts
@@ -1,0 +1,219 @@
+import { useState, useEffect, useRef } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getAuthHeaders } from '../services/authFetch';
+import { API_BASE } from '../services/config';
+import type {
+  CoachMemoryContext,
+  GoalNode,
+  ToDoItem,
+  ShortTermMemory,
+  MidTermMemory,
+  LongTermMemory,
+} from '../shared/types';
+import { NodeType, NodeStatus } from '../shared/types';
+import type { AppLanguage } from '../shared/i18n/types';
+
+const API_CHAT = `${API_BASE}/api/chat`;
+
+const STORAGE_PREFIX = 'secretcoach-memory';
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+// ── Goal / Todo context builders ──
+
+export const buildGoalContext = (
+  nodes: GoalNode[],
+  language: AppLanguage = 'ko',
+): string => {
+  if (!nodes.length) return language === 'ko' ? '목표 없음' : 'No goals';
+
+  const root = nodes.find((n) => n.type === NodeType.ROOT);
+  const children = nodes.filter((n) => n.type === NodeType.SUB);
+  const progressLabel = language === 'ko' ? '진행률' : 'progress';
+
+  const lines: string[] = [];
+  if (root) {
+    lines.push(`[ROOT] ${root.text} (${progressLabel} ${root.progress}%)`);
+  }
+
+  for (const child of children) {
+    const statusTag =
+      child.status === NodeStatus.COMPLETED
+        ? ' ✓'
+        : child.status === NodeStatus.STUCK
+          ? ' ⚠'
+          : '';
+    lines.push(
+      `  ├ ${child.text} (${progressLabel} ${child.progress}%, ${child.status}${statusTag})`,
+    );
+  }
+
+  return lines.join('\n');
+};
+
+export const buildTodoContext = (
+  todos: ToDoItem[],
+  language: AppLanguage = 'ko',
+): string => {
+  if (!todos.length) return language === 'ko' ? '할일 없음' : 'No todos';
+
+  const completed = todos.filter((t) => t.completed).length;
+  const header =
+    language === 'ko'
+      ? `오늘 할일: ${completed}/${todos.length} 완료`
+      : `Today: ${completed}/${todos.length} completed`;
+  const lines = [header];
+
+  const priorityLabel: Record<string, string> =
+    language === 'ko'
+      ? { high: '높음', medium: '보통', low: '낮음' }
+      : { high: 'high', medium: 'medium', low: 'low' };
+
+  for (const todo of todos) {
+    const icon = todo.completed ? '✓' : '□';
+    const pLabel = priorityLabel[todo.priority || 'medium'];
+    lines.push(`${icon} ${todo.text} (${pLabel})`);
+  }
+
+  return lines.join('\n');
+};
+
+// ── AsyncStorage-based memory (replaces localStorage) ──
+
+const EMPTY_MEMORY: CoachMemoryContext = {
+  shortTerm: null,
+  midTerm: null,
+  longTerm: null,
+};
+
+interface StoredMemoryData {
+  memory: CoachMemoryContext;
+  shortTermUpdatedAt: number;
+  midTermUpdatedAt: number;
+}
+
+const loadStoredMemory = async (): Promise<StoredMemoryData> => {
+  try {
+    const [short, mid, long] = await Promise.all([
+      AsyncStorage.getItem(`${STORAGE_PREFIX}-shortTerm`),
+      AsyncStorage.getItem(`${STORAGE_PREFIX}-midTerm`),
+      AsyncStorage.getItem(`${STORAGE_PREFIX}-longTerm`),
+    ]);
+    const shortParsed = short ? (JSON.parse(short) as ShortTermMemory) : null;
+    const midParsed = mid ? (JSON.parse(mid) as MidTermMemory) : null;
+    const longParsed = long ? (JSON.parse(long) as LongTermMemory) : null;
+    return {
+      memory: {
+        shortTerm: shortParsed?.summary ?? null,
+        midTerm: midParsed?.summary ?? null,
+        longTerm: longParsed?.summary ?? null,
+      },
+      shortTermUpdatedAt: shortParsed?.updatedAt ?? 0,
+      midTermUpdatedAt: midParsed?.updatedAt ?? 0,
+    };
+  } catch {
+    return {
+      memory: EMPTY_MEMORY,
+      shortTermUpdatedAt: 0,
+      midTermUpdatedAt: 0,
+    };
+  }
+};
+
+// ── Hook ──
+
+export const useCoachMemory = (
+  userId: string | null,
+  isOpen: boolean,
+  nodes: GoalNode[],
+  todos: ToDoItem[],
+  language: AppLanguage = 'ko',
+) => {
+  const [memory, setMemory] = useState<CoachMemoryContext>(EMPTY_MEMORY);
+  const activeRef = useRef(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      activeRef.current = false;
+      setMemory(EMPTY_MEMORY);
+      return;
+    }
+    if (activeRef.current) return;
+    activeRef.current = true;
+
+    // Phase 1: load cached memory quickly
+    loadStoredMemory()
+      .then(({ memory: cached }) => {
+        setMemory(cached);
+      })
+      .catch(() => {});
+
+    // Phase 2: background refresh
+    refreshInBackground(userId)
+      .then((updated) => {
+        if (updated) setMemory(updated);
+      })
+      .catch(() => {});
+  }, [isOpen, userId, nodes, todos, language]);
+
+  return memory;
+};
+
+const isMidTermStale = (midTermUpdatedAt: number): boolean =>
+  Date.now() - midTermUpdatedAt > SEVEN_DAYS_MS;
+
+async function refreshInBackground(
+  userId: string | null,
+): Promise<CoachMemoryContext | null> {
+  if (!userId) return null;
+
+  try {
+    const stored = await loadStoredMemory();
+    const existing = stored.memory;
+    const timestamps = {
+      shortTermUpdatedAt: stored.shortTermUpdatedAt,
+      midTermUpdatedAt: stored.midTermUpdatedAt,
+    };
+
+    let changed = false;
+
+    // Mid-term + long-term memory refresh when stale (>7 days)
+    if (isMidTermStale(timestamps.midTermUpdatedAt)) {
+      try {
+        const midRes = await fetch(API_CHAT, {
+          method: 'POST',
+          headers: await getAuthHeaders(),
+          body: JSON.stringify({
+            action: 'summarize-mid',
+            userId,
+            existingMemory: existing,
+          }),
+        });
+        if (midRes.ok) {
+          existing.midTerm = (await midRes.json()).summary;
+          changed = true;
+        }
+
+        const longRes = await fetch(API_CHAT, {
+          method: 'POST',
+          headers: await getAuthHeaders(),
+          body: JSON.stringify({
+            action: 'promote-long',
+            userId,
+            existingMemory: existing,
+            feedbackHistory: [],
+          }),
+        });
+        if (longRes.ok) {
+          existing.longTerm = (await longRes.json()).summary;
+          changed = true;
+        }
+      } catch {
+        /* stale data is fine */
+      }
+    }
+
+    return changed ? existing : null;
+  } catch {
+    return null;
+  }
+}

--- a/supercoach-ai-native/hooks/useDreamChat.ts
+++ b/supercoach-ai-native/hooks/useDreamChat.ts
@@ -1,0 +1,108 @@
+import { useState, useCallback } from 'react';
+import { sendDreamChatMessage } from '../services/aiService';
+import type { AppLanguage } from '../shared/i18n/types';
+
+export interface ChatMessage {
+  id: string;
+  role: 'ai' | 'user';
+  content: string;
+  type: 'suggestion' | 'scene' | 'user-input';
+}
+
+const getWelcomeMessage = (lang: AppLanguage) =>
+  lang === 'ko'
+    ? '안녕하세요! 어떤 장면을 시각화해 볼까요? 아래에서 마음에 드는 주제를 선택하거나 직접 입력해 주세요.'
+    : 'Hello! What scene would you like to visualize? Choose a topic below or type your own.';
+
+const getErrorMessage = (lang: AppLanguage) =>
+  lang === 'ko'
+    ? '죄송해요, 잠시 오류가 발생했어요. 다시 시도해 주세요.'
+    : 'Sorry, an error occurred. Please try again.';
+
+const makeId = () =>
+  `${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+
+export function useDreamChat(language: AppLanguage = 'ko') {
+  const welcomeMessage = getWelcomeMessage(language);
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    { id: makeId(), role: 'ai', content: welcomeMessage, type: 'scene' },
+  ]);
+  const [isAiTyping, setIsAiTyping] = useState(false);
+  const [finalPrompt, setFinalPrompt] = useState<string | null>(null);
+  const addMessage = useCallback(
+    (
+      role: ChatMessage['role'],
+      content: string,
+      type: ChatMessage['type'],
+    ) => {
+      const msg: ChatMessage = { id: makeId(), role, content, type };
+      setMessages((prev) => [...prev, msg]);
+      return msg;
+    },
+    [],
+  );
+
+  const sendMessage = useCallback(
+    async (text: string, goals: string[] = []) => {
+      addMessage('user', text, 'user-input');
+      setIsAiTyping(true);
+      setFinalPrompt(null);
+
+      try {
+        const history = [
+          ...messages,
+          { id: '', role: 'user' as const, content: text, type: 'user-input' as const },
+        ]
+          .filter((m) => m.content !== welcomeMessage)
+          .map((m) => ({
+            role: m.role === 'user' ? 'user' : 'assistant',
+            content: m.content,
+          }));
+
+        const { reply, prompt } = await sendDreamChatMessage(
+          history.slice(0, -1),
+          text,
+          goals,
+        );
+
+        addMessage('ai', reply, 'scene');
+        if (prompt) setFinalPrompt(prompt);
+      } catch {
+        addMessage('ai', getErrorMessage(language), 'scene');
+      } finally {
+        setIsAiTyping(false);
+      }
+    },
+    [addMessage, messages, language, welcomeMessage],
+  );
+
+  const clearMessages = useCallback(() => {
+    setMessages([
+      { id: makeId(), role: 'ai', content: welcomeMessage, type: 'scene' },
+    ]);
+    setFinalPrompt(null);
+  }, [welcomeMessage]);
+
+  const getLastScene = useCallback((): string => {
+    if (finalPrompt) return finalPrompt;
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      if (messages[i].role === 'ai' && messages[i].type === 'scene') {
+        return messages[i].content;
+      }
+    }
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      if (messages[i].role === 'user') return messages[i].content;
+    }
+    return '';
+  }, [messages, finalPrompt]);
+
+  return {
+    messages,
+    addMessage,
+    sendMessage,
+    clearMessages,
+    getLastScene,
+    isAiTyping,
+    finalPrompt,
+  };
+}

--- a/supercoach-ai-native/hooks/useNotifications.ts
+++ b/supercoach-ai-native/hooks/useNotifications.ts
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { AppState } from 'react-native';
+import type { NotificationSettings } from '../shared/types';
+import type { AlarmSlot } from '../services/notificationService';
+import {
+  registerForPushNotifications,
+  checkNotificationTriggers,
+  showNotification,
+  markMorningSent,
+  markEveningSent,
+  addNotificationResponseListener,
+} from '../services/notificationService';
+
+const CHECK_INTERVAL_MS = 60_000; // 1 minute
+
+// Re-export AlarmSlot from the service so consumers can import from either place
+export type { AlarmSlot } from '../services/notificationService';
+
+interface UseNotificationsOptions {
+  /** Current notification settings from user profile / store. */
+  settings: NotificationSettings | null;
+  /** Called when the user taps a notification. */
+  onNotificationTap?: (slot: AlarmSlot | null, data?: Record<string, unknown>) => void;
+  /** Called after a push token is obtained. */
+  onTokenReceived?: (token: string) => void;
+}
+
+export function useNotifications({
+  settings,
+  onNotificationTap,
+  onTokenReceived,
+}: UseNotificationsOptions) {
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // --- Trigger check callback ---
+  const runTriggerCheck = useCallback(async () => {
+    if (!settings) return;
+
+    const result = await checkNotificationTriggers(settings);
+
+    if (result.shouldNotifyMorning) {
+      await showNotification(
+        'Good morning!',
+        "Check today's goals and get started.",
+        { slot: 'morning' },
+      );
+      await markMorningSent();
+    }
+
+    if (result.shouldNotifyEvening) {
+      await showNotification(
+        'Evening check-in',
+        'How did today go? Review your progress.',
+        { slot: 'evening' },
+      );
+      await markEveningSent();
+    }
+  }, [settings]);
+
+  // --- Initialise on mount ---
+  useEffect(() => {
+    let mounted = true;
+
+    async function init() {
+      // registerForPushNotifications handles permissions + channel setup internally
+      const token = await registerForPushNotifications();
+      if (token && mounted) {
+        onTokenReceived?.(token);
+      }
+    }
+
+    init();
+
+    return () => {
+      mounted = false;
+    };
+    // Only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // --- Notification tap handler ---
+  useEffect(() => {
+    const sub = addNotificationResponseListener((response) => {
+      const data = response.notification.request.content.data as
+        | Record<string, unknown>
+        | undefined;
+      const slot = (data?.slot as AlarmSlot) ?? null;
+      onNotificationTap?.(slot, data);
+    });
+
+    return () => sub.remove();
+  }, [onNotificationTap]);
+
+  // --- Periodic trigger checking ---
+  useEffect(() => {
+    // Run immediately on settings change
+    runTriggerCheck();
+
+    intervalRef.current = setInterval(runTriggerCheck, CHECK_INTERVAL_MS);
+
+    // Pause when app is backgrounded, resume on foreground
+    const appStateSub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        runTriggerCheck();
+        if (!intervalRef.current) {
+          intervalRef.current = setInterval(runTriggerCheck, CHECK_INTERVAL_MS);
+        }
+      } else if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    });
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      appStateSub.remove();
+    };
+  }, [runTriggerCheck]);
+}

--- a/supercoach-ai-native/services/actionLogService.ts
+++ b/supercoach-ai-native/services/actionLogService.ts
@@ -1,0 +1,120 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import firestore from '@react-native-firebase/firestore';
+import type { ActionType, ActionLogEntry } from '../shared/types';
+import { isGuestUser } from '../shared/isGuestUser';
+
+const STORAGE_KEY = 'secretcoach-action-log';
+const MAX_LOCAL_ENTRIES = 100;
+const CLEANUP_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+export const appendAction = async (
+  userId: string | null,
+  action: ActionType,
+  detail: string,
+  metadata?: Record<string, unknown>,
+): Promise<void> => {
+  const entry: ActionLogEntry = {
+    id: `${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+    action,
+    detail,
+    timestamp: Date.now(),
+    metadata,
+  };
+
+  if (isGuestUser(userId)) {
+    await appendToAsyncStorage(entry);
+    return;
+  }
+
+  await appendToAsyncStorage(entry);
+  firestore()
+    .collection('users')
+    .doc(userId!)
+    .collection('actionLog')
+    .add({ action: entry.action, detail: entry.detail, timestamp: entry.timestamp, metadata: entry.metadata || null })
+    .catch((e) => { console.error('[ActionLog] Write failed:', (e as { code?: string })?.code || e); });
+};
+
+export const getRecentActions = async (
+  userId: string | null,
+  sinceDays: number = 7,
+): Promise<ActionLogEntry[]> => {
+  const sinceTimestamp = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
+
+  if (isGuestUser(userId)) {
+    const local = await getFromAsyncStorage();
+    return local.filter(e => e.timestamp >= sinceTimestamp);
+  }
+
+  try {
+    const snap = await firestore()
+      .collection('users')
+      .doc(userId!)
+      .collection('actionLog')
+      .where('timestamp', '>=', sinceTimestamp)
+      .orderBy('timestamp', 'desc')
+      .limit(200)
+      .get();
+
+    return snap.docs.map(d => ({
+      id: d.id,
+      ...d.data(),
+    })) as ActionLogEntry[];
+  } catch {
+    const local = await getFromAsyncStorage();
+    return local.filter(e => e.timestamp >= sinceTimestamp);
+  }
+};
+
+export const cleanupOldActions = async (
+  userId: string | null,
+): Promise<void> => {
+  await cleanupAsyncStorage();
+
+  if (isGuestUser(userId)) return;
+
+  try {
+    const cutoff = Date.now() - CLEANUP_AGE_MS;
+    const snap = await firestore()
+      .collection('users')
+      .doc(userId!)
+      .collection('actionLog')
+      .where('timestamp', '<', cutoff)
+      .limit(100)
+      .get();
+
+    if (snap.empty) return;
+
+    const batch = firestore().batch();
+    snap.docs.forEach(d => batch.delete(d.ref));
+    await batch.commit();
+  } catch { /* best effort */ }
+};
+
+const appendToAsyncStorage = async (entry: ActionLogEntry): Promise<void> => {
+  try {
+    const stored = await AsyncStorage.getItem(STORAGE_KEY);
+    const entries: ActionLogEntry[] = stored ? JSON.parse(stored) : [];
+    entries.push(entry);
+    const trimmed = entries.slice(-MAX_LOCAL_ENTRIES);
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+  } catch { /* ignore */ }
+};
+
+const getFromAsyncStorage = async (): Promise<ActionLogEntry[]> => {
+  try {
+    const stored = await AsyncStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+};
+
+const cleanupAsyncStorage = async (): Promise<void> => {
+  try {
+    const cutoff = Date.now() - CLEANUP_AGE_MS;
+    const entries = await getFromAsyncStorage();
+    const filtered = entries.filter(e => e.timestamp >= cutoff);
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+  } catch { /* ignore */ }
+};

--- a/supercoach-ai-native/services/aiService.ts
+++ b/supercoach-ai-native/services/aiService.ts
@@ -1,0 +1,646 @@
+import type { UserProfile, CoachMemoryContext } from '../shared/types';
+import { getAuthHeaders } from './authFetch';
+import { API_BASE } from './config';
+
+const authHeaders = async (): Promise<Record<string, string>> => {
+  try {
+    return await getAuthHeaders();
+  } catch {
+    return { 'Content-Type': 'application/json' };
+  }
+};
+
+export interface ChatApiResponse {
+  candidates?: {
+    content?: {
+      parts?: {
+        text?: string;
+      }[];
+    };
+  }[];
+}
+
+type ApiErrorPayload = {
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  requestId?: string | null;
+};
+
+const toOptionalString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const parseJsonSafe = async <T = Record<string, unknown>>(
+  response: Response,
+): Promise<T> => {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    return {} as T;
+  }
+};
+
+const sleep = async (ms: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const isRetryableStatus = (status: number): boolean => {
+  return status === 429 || status >= 500;
+};
+
+const fetchWithRetry = async (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  maxRetries: number = 1,
+): Promise<Response> => {
+  let attempt = 0;
+
+  while (attempt <= maxRetries) {
+    try {
+      const response = await fetch(input, init);
+      if (isRetryableStatus(response.status) && attempt < maxRetries) {
+        attempt += 1;
+        await sleep(300 * attempt);
+        continue;
+      }
+      return response;
+    } catch (error) {
+      if (attempt >= maxRetries) throw error;
+      attempt += 1;
+      await sleep(300 * attempt);
+    }
+  }
+
+  throw new Error('Fetch retry failed');
+};
+
+const toApiError = (
+  payload: Record<string, unknown>,
+  statusCode: number,
+  defaultCode: string,
+  defaultMessage: string,
+): Required<ApiErrorPayload> => {
+  const errorCode =
+    toOptionalString(payload.errorCode) ||
+    toOptionalString(payload.code) ||
+    `${defaultCode}_${statusCode}`;
+  const errorMessage =
+    toOptionalString(payload.errorMessage) ||
+    toOptionalString(payload.message) ||
+    defaultMessage;
+  const requestId = toOptionalString(payload.requestId) || 'n/a';
+  return { errorCode, errorMessage, requestId };
+};
+
+export const sendChatMessage = async (
+  history: { role: string; parts: { text?: string }[] }[],
+  newMessage: string,
+  profile: UserProfile | null,
+  memory: CoachMemoryContext,
+  goalContext: string,
+  todoContext: string,
+  activeTab?: string,
+  userId?: string,
+  goalCount?: number,
+  topicDirective?: string,
+  imageDataUrl?: string,
+): Promise<ChatApiResponse> => {
+  try {
+    const response = await fetch(`${API_BASE}/api/chat`, {
+      method: 'POST',
+      headers: await authHeaders(),
+      body: JSON.stringify({
+        history,
+        message: newMessage,
+        profile,
+        memory,
+        goalContext,
+        todoContext,
+        activeTab,
+        userId,
+        goalCount,
+        topicDirective,
+        ...(imageDataUrl && { imageDataUrl }),
+      }),
+    });
+    if (response.status === 429) {
+      const data = await response.json();
+      throw new Error(data.message || 'Monthly usage limit exceeded');
+    }
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText);
+    }
+    return response.json();
+  } catch (error) {
+    console.error('Chat API Error:', error);
+    throw error;
+  }
+};
+
+export interface ImageGenerationResult {
+  status: 'completed' | 'failed';
+  imageUrl?: string;
+  imageDataUrl?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  requestId?: string;
+}
+
+export const generateGoalImage = async (
+  goalText: string,
+  profile: UserProfile | null = null,
+  childTexts: string[] = [],
+  userId?: string | null,
+  nodeId?: string,
+): Promise<string | undefined> => {
+  try {
+    const response = await fetch(`${API_BASE}/api/generate-image`, {
+      method: 'POST',
+      headers: await authHeaders(),
+      body: JSON.stringify({
+        prompt: goalText,
+        profile,
+        childTexts,
+        userId,
+        nodeId,
+        imagePurpose: 'node',
+      }),
+    });
+    if (!response.ok) return undefined;
+    const data = await response.json();
+    return data.imageUrl || data.imageDataUrl || undefined;
+  } catch (error) {
+    console.error('Image Gen Error:', error);
+    return undefined;
+  }
+};
+
+export const generateVisualizationImage = async (
+  prompt: string,
+  referenceImages: string[],
+  profile: UserProfile | null = null,
+  imageQuality: 'medium' | 'high' = 'medium',
+  userId?: string | null,
+  visualizationId?: string,
+): Promise<ImageGenerationResult> => {
+  try {
+    const response = await fetchWithRetry(
+      `${API_BASE}/api/generate-image`,
+      {
+        method: 'POST',
+        headers: await authHeaders(),
+        body: JSON.stringify({
+          prompt,
+          profile,
+          referenceImages,
+          userId,
+          visualizationId,
+          imagePurpose: 'visualization',
+          imageQuality,
+        }),
+      },
+      0,
+    );
+
+    const payload = await parseJsonSafe<Record<string, unknown>>(response);
+    if (!response.ok) {
+      const apiError = toApiError(
+        payload,
+        response.status,
+        'IMAGE_API_ERROR',
+        'Image generation failed.',
+      );
+      return {
+        status: 'failed',
+        errorCode: apiError.errorCode,
+        errorMessage: apiError.errorMessage,
+        requestId: apiError.requestId,
+      };
+    }
+
+    const imageUrl =
+      toOptionalString(payload.imageUrl) ||
+      toOptionalString(payload.imageDataUrl);
+    const imageDataUrl = toOptionalString(payload.imageDataUrl);
+    const imageStatus = toOptionalString(payload.status);
+    if (!imageUrl || (imageStatus && imageStatus !== 'completed')) {
+      return {
+        status: 'failed',
+        errorCode: toOptionalString(payload.errorCode) || 'IMAGE_EMPTY_RESULT',
+        errorMessage:
+          toOptionalString(payload.errorMessage) ||
+          'Image generation result is empty.',
+        requestId: toOptionalString(payload.requestId),
+      };
+    }
+
+    return {
+      status: 'completed',
+      imageUrl,
+      imageDataUrl,
+      requestId: toOptionalString(payload.requestId),
+    };
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      status: 'failed',
+      errorCode: 'IMAGE_NETWORK_ERROR',
+      errorMessage: `Image generation failed: ${detail}`,
+    };
+  }
+};
+
+export const generateSuccessNarrative = async (
+  goalContext: string,
+  profile: UserProfile | null,
+  userId?: string,
+): Promise<string> => {
+  try {
+    const response = await fetch(`${API_BASE}/api/generate-narrative`, {
+      method: 'POST',
+      headers: await authHeaders(),
+      body: JSON.stringify({ goalContext, profile, userId }),
+    });
+    if (response.status === 429) {
+      const data = await response.json();
+      throw new Error(data.message || 'Monthly usage limit exceeded');
+    }
+    if (!response.ok) return '';
+    const data = await response.json();
+    return data.text || '';
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('usage limit')) throw err;
+    return '';
+  }
+};
+
+export interface AudioGenerationResult {
+  status: 'completed' | 'failed';
+  audioUrl?: string;
+  audioData?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  requestId?: string;
+}
+
+export const generateSpeech = async (
+  text: string,
+  userId?: string | null,
+  visualizationId?: string,
+): Promise<AudioGenerationResult> => {
+  try {
+    const response = await fetchWithRetry(
+      `${API_BASE}/api/generate-speech`,
+      {
+        method: 'POST',
+        headers: await authHeaders(),
+        body: JSON.stringify({ text, userId, visualizationId }),
+      },
+      0,
+    );
+
+    const payload = await parseJsonSafe<Record<string, unknown>>(response);
+    if (!response.ok) {
+      const apiError = toApiError(
+        payload,
+        response.status,
+        'SPEECH_API_ERROR',
+        'Audio generation failed.',
+      );
+      return {
+        status: 'failed',
+        errorCode: apiError.errorCode,
+        errorMessage: apiError.errorMessage,
+        requestId: apiError.requestId,
+      };
+    }
+
+    const audioUrl = toOptionalString(payload.audioUrl);
+    const audioData = toOptionalString(payload.audioData);
+    if (
+      toOptionalString(payload.status) !== 'completed' ||
+      (!audioUrl && !audioData)
+    ) {
+      return {
+        status: 'failed',
+        errorCode:
+          toOptionalString(payload.errorCode) || 'SPEECH_EMPTY_AUDIO',
+        errorMessage:
+          toOptionalString(payload.errorMessage) ||
+          'Audio generation result is empty.',
+        requestId: toOptionalString(payload.requestId),
+      };
+    }
+
+    return {
+      status: 'completed',
+      audioUrl,
+      audioData,
+      requestId: toOptionalString(payload.requestId),
+    };
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      status: 'failed',
+      errorCode: 'SPEECH_NETWORK_ERROR',
+      errorMessage: `Audio generation failed: ${detail}`,
+    };
+  }
+};
+
+export interface DreamChatResponse {
+  reply: string;
+  prompt: string | null;
+}
+
+export const sendDreamChatMessage = async (
+  history: { role: string; content: string }[],
+  message: string,
+  goals: string[] = [],
+): Promise<DreamChatResponse> => {
+  const response = await fetch(`${API_BASE}/api/dream-chat`, {
+    method: 'POST',
+    headers: await authHeaders(),
+    body: JSON.stringify({ history, message, goals }),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || 'Dream chat request failed');
+  }
+  return response.json();
+};
+
+export const generateFeedback = async (
+  period: 'daily' | 'weekly' | 'monthly',
+  profile: UserProfile | null,
+  goalContext: string,
+  todoContext: string,
+  statsContext: string,
+  userId?: string | null,
+): Promise<string> => {
+  try {
+    const response = await fetch(`${API_BASE}/api/generate-feedback`, {
+      method: 'POST',
+      headers: await authHeaders(),
+      body: JSON.stringify({
+        period,
+        profile,
+        goalContext,
+        todoContext,
+        statsContext,
+        userId: userId || undefined,
+      }),
+    });
+    if (response.status === 429) {
+      const data = await response.json();
+      throw new Error(data.message || 'Usage limit exceeded');
+    }
+    if (!response.ok) return '';
+    const data = await response.json();
+    return data.text || '';
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('usage limit')) throw err;
+    return '';
+  }
+};
+
+export const decomposeGoal = async (
+  parentText: string,
+  childTexts: string[],
+  userId?: string | null,
+): Promise<string[]> => {
+  try {
+    const headers = await authHeaders();
+    const response = await fetchWithRetry(`${API_BASE}/api/decompose-goal`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ parentText, childTexts, userId }),
+    });
+
+    if (!response.ok) return [];
+    const data = await parseJsonSafe<{ suggestions?: string[] }>(response);
+    return Array.isArray(data.suggestions) ? data.suggestions : [];
+  } catch {
+    return [];
+  }
+};
+
+// ---------- Video Generation ----------
+
+export type VideoGenerationStatus =
+  | 'queued'
+  | 'in_progress'
+  | 'completed'
+  | 'failed'
+  | 'unknown';
+
+export interface VideoGenerationResult {
+  videoUrl?: string;
+  videoId?: string;
+  status: VideoGenerationStatus;
+  durationSec: number;
+  errorCode?: string;
+  errorMessage?: string;
+  requestId?: string;
+}
+
+const toVideoStatus = (value: unknown): VideoGenerationStatus => {
+  const normalized = String(value || '').toLowerCase();
+  if (normalized === 'queued') return 'queued';
+  if (normalized === 'in_progress') return 'in_progress';
+  if (normalized === 'completed') return 'completed';
+  if (normalized === 'failed') return 'failed';
+  return 'unknown';
+};
+
+const toVideoResult = (
+  payload: Record<string, unknown>,
+  fallbackDurationSec: number,
+): VideoGenerationResult => ({
+  videoUrl: toOptionalString(payload.videoUrl),
+  videoId: toOptionalString(payload.videoId),
+  status: toVideoStatus(payload.status),
+  durationSec: Number(payload.durationSec || fallbackDurationSec || 4),
+  errorCode: toOptionalString(payload.errorCode),
+  errorMessage: toOptionalString(payload.errorMessage),
+  requestId: toOptionalString(payload.requestId),
+});
+
+const isTransientVideoError = (errorCode?: string): boolean => {
+  if (!errorCode) return false;
+  if (errorCode.includes('NETWORK')) return true;
+  return /(?:^|_)(429|5\d\d)$/.test(errorCode);
+};
+
+export const pollVideoStatus = async (
+  videoId: string,
+  userId?: string | null,
+  durationSec: number = 4,
+): Promise<VideoGenerationResult> => {
+  try {
+    const response = await fetchWithRetry(
+      `${API_BASE}/api/generate-video`,
+      {
+        method: 'POST',
+        headers: await authHeaders(),
+        body: JSON.stringify({ videoId, userId, durationSec }),
+      },
+      1,
+    );
+
+    const payload = await parseJsonSafe<Record<string, unknown>>(response);
+    if (!response.ok) {
+      const apiError = toApiError(
+        payload,
+        response.status,
+        'VIDEO_POLL_ERROR',
+        'Video status check failed.',
+      );
+      return {
+        videoId,
+        status: 'failed',
+        durationSec,
+        errorCode: apiError.errorCode,
+        errorMessage: apiError.errorMessage,
+        requestId: apiError.requestId,
+      };
+    }
+
+    const result = toVideoResult(payload, durationSec);
+    if (!result.videoId) result.videoId = videoId;
+    return result;
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      videoId,
+      status: 'failed',
+      durationSec,
+      errorCode: 'VIDEO_POLL_NETWORK_ERROR',
+      errorMessage: `Video status check failed: ${detail}`,
+    };
+  }
+};
+
+const TIMEOUT_MS = 90_000;
+
+export const generateVideo = async (
+  prompt: string,
+  profile: UserProfile | null,
+  durationSec: number = 4,
+): Promise<VideoGenerationResult> => {
+  try {
+    const userId = profile?.googleId || null;
+
+    const createResponse = await fetchWithRetry(
+      `${API_BASE}/api/generate-video`,
+      {
+        method: 'POST',
+        headers: await authHeaders(),
+        body: JSON.stringify({ prompt, profile, userId, durationSec }),
+      },
+      0,
+    );
+
+    const createPayload =
+      await parseJsonSafe<Record<string, unknown>>(createResponse);
+    if (!createResponse.ok) {
+      const apiError = toApiError(
+        createPayload,
+        createResponse.status,
+        'VIDEO_CREATE_ERROR',
+        'Video generation failed.',
+      );
+      return {
+        status: 'failed',
+        durationSec,
+        errorCode: apiError.errorCode,
+        errorMessage: apiError.errorMessage,
+        requestId: apiError.requestId,
+      };
+    }
+
+    const created = toVideoResult(createPayload, durationSec);
+    if (created.videoUrl) return created;
+    if (created.status === 'failed') return created;
+    if (!created.videoId) {
+      return {
+        ...created,
+        status: 'failed',
+        errorCode: created.errorCode || 'VIDEO_ID_MISSING',
+        errorMessage: created.errorMessage || 'No video ID received.',
+      };
+    }
+
+    const startedAt = Date.now();
+    let lastResult: VideoGenerationResult = created;
+
+    while (Date.now() - startedAt < TIMEOUT_MS) {
+      await sleep(5000);
+
+      const polled = await pollVideoStatus(created.videoId, userId, durationSec);
+      lastResult = polled;
+      if (polled.videoUrl) return polled;
+      if (
+        polled.status === 'failed' &&
+        !isTransientVideoError(polled.errorCode)
+      )
+        return polled;
+    }
+
+    if (
+      lastResult.videoId &&
+      (lastResult.status === 'queued' ||
+        lastResult.status === 'in_progress' ||
+        lastResult.status === 'unknown' ||
+        isTransientVideoError(lastResult.errorCode))
+    ) {
+      return {
+        ...lastResult,
+        status: lastResult.status === 'queued' ? 'queued' : 'in_progress',
+      };
+    }
+
+    return lastResult;
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      status: 'failed',
+      durationSec,
+      errorCode: 'VIDEO_CLIENT_EXCEPTION',
+      errorMessage: `Video generation error: ${detail}`,
+    };
+  }
+};
+
+// ---------- Visualization Asset Upload ----------
+
+type VisualizationAssetType = 'image' | 'audio' | 'video';
+
+export const uploadVisualizationAsset = async (
+  assetType: VisualizationAssetType,
+  userId: string,
+  visualizationId: string,
+  payload: { dataUrl?: string; audioData?: string },
+): Promise<string | undefined> => {
+  try {
+    const response = await fetch(`${API_BASE}/api/upload-visualization-asset`, {
+      method: 'POST',
+      headers: await authHeaders(),
+      body: JSON.stringify({
+        assetType,
+        userId,
+        visualizationId,
+        dataUrl: payload.dataUrl,
+        audioData: payload.audioData,
+      }),
+    });
+    if (!response.ok) return undefined;
+    const data = await response.json();
+    return data.assetUrl || undefined;
+  } catch {
+    return undefined;
+  }
+};

--- a/supercoach-ai-native/services/authFetch.ts
+++ b/supercoach-ai-native/services/authFetch.ts
@@ -1,0 +1,13 @@
+import auth from '@react-native-firebase/auth';
+
+export const getAuthHeaders = async (): Promise<Record<string, string>> => {
+  const user = auth().currentUser;
+  if (!user) {
+    throw new Error('AUTH_REQUIRED');
+  }
+  const token = await user.getIdToken();
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  };
+};

--- a/supercoach-ai-native/services/coachMemoryService.ts
+++ b/supercoach-ai-native/services/coachMemoryService.ts
@@ -1,0 +1,154 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import firestore from '@react-native-firebase/firestore';
+import type {
+  CoachMemoryContext,
+  ShortTermMemory,
+  MidTermMemory,
+  LongTermMemory,
+} from '../shared/types';
+import { isGuestUser } from '../shared/isGuestUser';
+
+const STORAGE_PREFIX = 'secretcoach-memory';
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+const memoryDoc = (userId: string, tier: string) =>
+  firestore().collection('users').doc(userId).collection('coachMemory').doc(tier);
+
+export const loadMemory = async (
+  userId: string | null,
+): Promise<CoachMemoryContext> => {
+  if (isGuestUser(userId)) return loadFromAsyncStorage();
+
+  try {
+    const [shortSnap, midSnap, longSnap] = await Promise.all([
+      memoryDoc(userId!, 'shortTerm').get(),
+      memoryDoc(userId!, 'midTerm').get(),
+      memoryDoc(userId!, 'longTerm').get(),
+    ]);
+
+    return {
+      shortTerm: (shortSnap.data() as ShortTermMemory | undefined)?.summary || null,
+      midTerm: (midSnap.data() as MidTermMemory | undefined)?.summary || null,
+      longTerm: (longSnap.data() as LongTermMemory | undefined)?.summary || null,
+    };
+  } catch {
+    return loadFromAsyncStorage();
+  }
+};
+
+export const loadMemoryTimestamps = async (
+  userId: string | null,
+): Promise<{ shortTermUpdatedAt: number; midTermUpdatedAt: number }> => {
+  if (isGuestUser(userId)) {
+    return loadTimestampsFromAsyncStorage();
+  }
+
+  try {
+    const [shortSnap, midSnap] = await Promise.all([
+      memoryDoc(userId!, 'shortTerm').get(),
+      memoryDoc(userId!, 'midTerm').get(),
+    ]);
+    return {
+      shortTermUpdatedAt: (shortSnap.data() as ShortTermMemory | undefined)?.updatedAt || 0,
+      midTermUpdatedAt: (midSnap.data() as MidTermMemory | undefined)?.updatedAt || 0,
+    };
+  } catch {
+    return loadTimestampsFromAsyncStorage();
+  }
+};
+
+export const saveShortTerm = async (
+  userId: string | null,
+  summary: string,
+  lastActionTimestamp: number,
+): Promise<void> => {
+  const data: ShortTermMemory = {
+    summary,
+    lastActionTimestamp,
+    updatedAt: Date.now(),
+  };
+
+  await saveToAsyncStorage('shortTerm', data);
+  if (isGuestUser(userId)) return;
+
+  try {
+    await memoryDoc(userId!, 'shortTerm').set(data);
+  } catch (e) { console.error('[CoachMemory:short] Save failed:', (e as { code?: string })?.code || e); }
+};
+
+export const saveMidTerm = async (
+  userId: string | null,
+  summary: string,
+): Promise<void> => {
+  const data: MidTermMemory = { summary, updatedAt: Date.now() };
+
+  await saveToAsyncStorage('midTerm', data);
+  if (isGuestUser(userId)) return;
+
+  try {
+    await memoryDoc(userId!, 'midTerm').set(data);
+  } catch (e) { console.error('[CoachMemory:mid] Save failed:', (e as { code?: string })?.code || e); }
+};
+
+export const saveLongTerm = async (
+  userId: string | null,
+  summary: string,
+): Promise<void> => {
+  const data: LongTermMemory = { summary, updatedAt: Date.now() };
+
+  await saveToAsyncStorage('longTerm', data);
+  if (isGuestUser(userId)) return;
+
+  try {
+    await memoryDoc(userId!, 'longTerm').set(data);
+  } catch (e) { console.error('[CoachMemory:long] Save failed:', (e as { code?: string })?.code || e); }
+};
+
+export const isMidTermStale = (midTermUpdatedAt: number): boolean =>
+  Date.now() - midTermUpdatedAt > SEVEN_DAYS_MS;
+
+// AsyncStorage fallback
+
+const loadFromAsyncStorage = async (): Promise<CoachMemoryContext> => {
+  try {
+    const [shortRaw, midRaw, longRaw] = await Promise.all([
+      AsyncStorage.getItem(`${STORAGE_PREFIX}-shortTerm`),
+      AsyncStorage.getItem(`${STORAGE_PREFIX}-midTerm`),
+      AsyncStorage.getItem(`${STORAGE_PREFIX}-longTerm`),
+    ]);
+    return {
+      shortTerm: shortRaw ? (JSON.parse(shortRaw) as ShortTermMemory).summary : null,
+      midTerm: midRaw ? (JSON.parse(midRaw) as MidTermMemory).summary : null,
+      longTerm: longRaw ? (JSON.parse(longRaw) as LongTermMemory).summary : null,
+    };
+  } catch {
+    return { shortTerm: null, midTerm: null, longTerm: null };
+  }
+};
+
+const loadTimestampsFromAsyncStorage = async (): Promise<{
+  shortTermUpdatedAt: number;
+  midTermUpdatedAt: number;
+}> => {
+  try {
+    const [shortRaw, midRaw] = await Promise.all([
+      AsyncStorage.getItem(`${STORAGE_PREFIX}-shortTerm`),
+      AsyncStorage.getItem(`${STORAGE_PREFIX}-midTerm`),
+    ]);
+    return {
+      shortTermUpdatedAt: shortRaw ? (JSON.parse(shortRaw) as ShortTermMemory).updatedAt : 0,
+      midTermUpdatedAt: midRaw ? (JSON.parse(midRaw) as MidTermMemory).updatedAt : 0,
+    };
+  } catch {
+    return { shortTermUpdatedAt: 0, midTermUpdatedAt: 0 };
+  }
+};
+
+const saveToAsyncStorage = async (
+  tier: 'shortTerm' | 'midTerm' | 'longTerm',
+  data: ShortTermMemory | MidTermMemory | LongTermMemory,
+): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(`${STORAGE_PREFIX}-${tier}`, JSON.stringify(data));
+  } catch { /* ignore */ }
+};

--- a/supercoach-ai-native/services/config.ts
+++ b/supercoach-ai-native/services/config.ts
@@ -1,0 +1,1 @@
+export const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? '';

--- a/supercoach-ai-native/services/notificationService.ts
+++ b/supercoach-ai-native/services/notificationService.ts
@@ -1,0 +1,221 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { NotificationSettings } from '../shared/types';
+
+// ---------- Constants ----------
+
+const SENT_KEY = 'feedback_notif_sent';
+const TRIGGER_WINDOW_MS = 5 * 60 * 1000;
+const ANDROID_CHANNEL_ID = 'supercoach-default';
+
+export type AlarmSlot = 'morning' | 'evening';
+
+// ---------- Notification channel setup (Android) ----------
+
+export async function setupNotificationChannel(): Promise<void> {
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync(ANDROID_CHANNEL_ID, {
+      name: 'SuperCoach Notifications',
+      importance: Notifications.AndroidImportance.HIGH,
+      sound: 'default',
+      vibrationPattern: [0, 250, 250, 250],
+    });
+  }
+}
+
+// ---------- Foreground notification handler ----------
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: true,
+  }),
+});
+
+// ---------- Permission & registration ----------
+
+export async function requestPermissions(): Promise<boolean> {
+  const { status: existing } = await Notifications.getPermissionsAsync();
+  if (existing === 'granted') return true;
+
+  const { status } = await Notifications.requestPermissionsAsync();
+  return status === 'granted';
+}
+
+export async function registerForPushNotifications(): Promise<string | null> {
+  try {
+    const granted = await requestPermissions();
+    if (!granted) return null;
+
+    await setupNotificationChannel();
+
+    const { data: token } = await Notifications.getDevicePushTokenAsync();
+    return typeof token === 'string' ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------- Local notification helpers ----------
+
+export async function scheduleLocalNotification(
+  title: string,
+  body: string,
+  options?: {
+    trigger?: Notifications.NotificationTriggerInput;
+    data?: Record<string, unknown>;
+  },
+): Promise<string> {
+  return Notifications.scheduleNotificationAsync({
+    content: {
+      title,
+      body,
+      data: options?.data,
+      sound: 'default',
+      ...(Platform.OS === 'android' && { channelId: ANDROID_CHANNEL_ID }),
+    },
+    trigger: options?.trigger ?? null,
+  });
+}
+
+export async function showNotification(
+  title: string,
+  body: string,
+  data?: Record<string, unknown>,
+): Promise<void> {
+  await scheduleLocalNotification(title, body, { data });
+}
+
+export async function cancelAllNotifications(): Promise<void> {
+  await Notifications.cancelAllScheduledNotificationsAsync();
+}
+
+// ---------- Response listener ----------
+
+export function addNotificationResponseListener(
+  handler: (response: Notifications.NotificationResponse) => void,
+): Notifications.Subscription {
+  return Notifications.addNotificationResponseReceivedListener(handler);
+}
+
+// ---------- Sent-record persistence (AsyncStorage) ----------
+
+async function getSentRecord(): Promise<Record<string, string>> {
+  try {
+    const raw = await AsyncStorage.getItem(SENT_KEY);
+    return raw ? (JSON.parse(raw) as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function markSent(type: string, dateKey: string): Promise<void> {
+  const record = await getSentRecord();
+  record[`${type}_${dateKey}`] = new Date().toISOString();
+
+  // Prune entries older than 3 days
+  const cutoff = Date.now() - 3 * 86_400_000;
+  for (const [k, v] of Object.entries(record)) {
+    if (new Date(v).getTime() < cutoff) delete record[k];
+  }
+  await AsyncStorage.setItem(SENT_KEY, JSON.stringify(record));
+}
+
+function checkSent(
+  record: Record<string, string>,
+  type: string,
+  dateKey: string,
+  settingsUpdatedAt = 0,
+): boolean {
+  const sentAtIso = record[`${type}_${dateKey}`];
+  if (!sentAtIso) return false;
+  const sentAt = new Date(sentAtIso).getTime();
+  if (!Number.isFinite(sentAt)) return false;
+  return sentAt >= settingsUpdatedAt;
+}
+
+// ---------- Time utilities ----------
+
+function todayKey(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function isWithinWindow(targetTime: string, windowMs = TRIGGER_WINDOW_MS): boolean {
+  const now = new Date();
+  const [h, m] = targetTime.split(':').map(Number);
+  const target = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, m, 0);
+  const diff = now.getTime() - target.getTime();
+  return diff >= 0 && diff < windowMs;
+}
+
+function isPastTime(targetTime: string): boolean {
+  const now = new Date();
+  const [h, m] = targetTime.split(':').map(Number);
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+  return nowMinutes >= h * 60 + m;
+}
+
+// ---------- Trigger check result ----------
+
+export interface NotificationCheckResult {
+  shouldNotifyMorning: boolean;
+  shouldNotifyEvening: boolean;
+  shouldGenerateVictory: boolean;
+}
+
+export async function checkNotificationTriggers(
+  settings: NotificationSettings | null,
+): Promise<NotificationCheckResult> {
+  const result: NotificationCheckResult = {
+    shouldNotifyMorning: false,
+    shouldNotifyEvening: false,
+    shouldGenerateVictory: false,
+  };
+
+  if (!settings) return result;
+  const today = todayKey();
+  const settingsUpdatedAt = Number(settings.updatedAt || 0);
+  const record = await getSentRecord();
+
+  if (settings.morningEnabled && !checkSent(record, 'morning', today, settingsUpdatedAt)) {
+    if (isWithinWindow(settings.morningTime)) {
+      result.shouldNotifyMorning = true;
+    }
+  }
+
+  if (settings.eveningEnabled && !checkSent(record, 'evening', today, settingsUpdatedAt)) {
+    if (isWithinWindow(settings.eveningTime)) {
+      result.shouldNotifyEvening = true;
+    }
+  }
+
+  if (settings.eveningEnabled && isPastTime(settings.eveningTime)) {
+    if (!checkSent(record, 'victory', today)) {
+      result.shouldGenerateVictory = true;
+    }
+  }
+
+  return result;
+}
+
+// ---------- Mark helpers ----------
+
+export async function markMorningSent(): Promise<void> {
+  await markSent('morning', todayKey());
+}
+
+export async function markEveningSent(): Promise<void> {
+  await markSent('evening', todayKey());
+}
+
+export async function markVictoryGenerated(): Promise<void> {
+  await markSent('victory', todayKey());
+}
+
+export async function wasVictoryGenerated(): Promise<boolean> {
+  const record = await getSentRecord();
+  return checkSent(record, 'victory', todayKey());
+}

--- a/supercoach-ai-native/shared/i18nTypes.ts
+++ b/supercoach-ai-native/shared/i18nTypes.ts
@@ -1,0 +1,1 @@
+export type AppLanguage = 'en' | 'ko';

--- a/supercoach-ai-native/shared/isGuestUser.ts
+++ b/supercoach-ai-native/shared/isGuestUser.ts
@@ -1,0 +1,2 @@
+export const isGuestUser = (uid?: string | null): boolean =>
+  !uid || uid === 'guest' || uid.startsWith('guest_');

--- a/supercoach-ai-native/stores/useThemeStore.ts
+++ b/supercoach-ai-native/stores/useThemeStore.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { Appearance } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+type ThemePreference = 'light' | 'dark' | 'system';
+
+interface ThemeState {
+  preference: ThemePreference;
+  resolved: 'light' | 'dark';
+  setTheme: (pref: ThemePreference) => void;
+}
+
+const resolveTheme = (pref: ThemePreference): 'light' | 'dark' => {
+  if (pref === 'system') {
+    const scheme: ColorSchemeName = Appearance.getColorScheme();
+    return scheme === 'dark' ? 'dark' : 'light';
+  }
+  return pref;
+};
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      preference: 'dark',
+      resolved: resolveTheme('dark'),
+      setTheme: (pref) => {
+        const resolved = resolveTheme(pref);
+        set({ preference: pref, resolved });
+      },
+    }),
+    {
+      name: 'secretcoach-theme',
+      storage: createJSONStorage(() => AsyncStorage),
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          const resolved = resolveTheme(state.preference);
+          if (resolved !== state.resolved) {
+            state.resolved = resolved;
+          }
+        }
+      },
+    }
+  )
+);
+
+/**
+ * Subscribe to OS-level color scheme changes.
+ * Call once at app root; returns an unsubscribe function.
+ */
+export const subscribeToSystemTheme = (): (() => void) => {
+  const subscription = Appearance.addChangeListener(() => {
+    const { preference, setTheme } = useThemeStore.getState();
+    if (preference === 'system') {
+      setTheme('system');
+    }
+  });
+  return () => subscription.remove();
+};

--- a/supercoach-ai-native/stores/useTodoStore.ts
+++ b/supercoach-ai-native/stores/useTodoStore.ts
@@ -1,0 +1,115 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { ToDoItem } from '../shared/types';
+
+interface TodoState {
+  // State
+  todos: ToDoItem[];
+  filter: 'all' | 'pending' | 'completed';
+  sortBy: 'dueDate' | 'priority' | 'createdAt';
+  isLoading: boolean;
+  error: string | null;
+
+  // Actions
+  setTodos: (todos: ToDoItem[]) => void;
+  addTodo: (todo: ToDoItem) => void;
+  updateTodo: (id: string, updates: Partial<ToDoItem>) => void;
+  deleteTodo: (id: string) => void;
+  toggleComplete: (id: string) => void;
+  setFilter: (filter: 'all' | 'pending' | 'completed') => void;
+  setSortBy: (sortBy: 'dueDate' | 'priority' | 'createdAt') => void;
+  getFilteredTodos: () => ToDoItem[];
+  getTodosForGoal: (goalId: string) => ToDoItem[];
+  reset: () => void;
+}
+
+const initialState = {
+  todos: [],
+  filter: 'all' as const,
+  sortBy: 'createdAt' as const,
+  isLoading: false,
+  error: null,
+};
+
+export const useTodoStore = create<TodoState>()(
+  persist(
+    (set, get) => ({
+      ...initialState,
+
+      setTodos: (todos) => set({ todos, error: null }),
+
+      addTodo: (todo) =>
+        set((state) => ({
+          todos: [todo, ...state.todos],
+          error: null,
+        })),
+
+      updateTodo: (id, updates) =>
+        set((state) => ({
+          todos: state.todos.map((todo) =>
+            todo.id === id ? { ...todo, ...updates } : todo
+          ),
+          error: null,
+        })),
+
+      deleteTodo: (id) =>
+        set((state) => ({
+          todos: state.todos.filter((todo) => todo.id !== id),
+          error: null,
+        })),
+
+      toggleComplete: (id) =>
+        set((state) => ({
+          todos: state.todos.map((todo) =>
+            todo.id === id ? { ...todo, completed: !todo.completed } : todo
+          ),
+          error: null,
+        })),
+
+      setFilter: (filter) => set({ filter }),
+
+      setSortBy: (sortBy) => set({ sortBy }),
+
+      getFilteredTodos: () => {
+        const { todos, filter, sortBy } = get();
+
+        let filtered = todos;
+        if (filter === 'pending') {
+          filtered = todos.filter((todo) => !todo.completed);
+        } else if (filter === 'completed') {
+          filtered = todos.filter((todo) => todo.completed);
+        }
+
+        const sorted = [...filtered].sort((a, b) => {
+          if (sortBy === 'dueDate') {
+            const aDate = a.dueDate || Number.MAX_SAFE_INTEGER;
+            const bDate = b.dueDate || Number.MAX_SAFE_INTEGER;
+            return aDate - bDate;
+          } else if (sortBy === 'createdAt') {
+            return b.createdAt - a.createdAt;
+          }
+          return 0;
+        });
+
+        return sorted;
+      },
+
+      getTodosForGoal: (goalId) => {
+        const { todos } = get();
+        return todos.filter((todo) => todo.linkedNodeId === goalId);
+      },
+
+      reset: () => set(initialState),
+    }),
+    {
+      name: 'secretcoach-todo-storage',
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({
+        todos: state.todos,
+        filter: state.filter,
+        sortBy: state.sortBy,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
## Summary
- Custom SVG-based mind map replacing web-only `simple-mind-map` library
- Tree layout algorithm (simplified Reingold-Tilford) for automatic node positioning
- Pan/zoom gestures via `react-native-gesture-handler` + `react-native-reanimated`
- Node rendering with status colors (PENDING/COMPLETED/STUCK), progress bars, and selection states
- Cubic bezier edge connections between parent-child nodes
- Floating action bar with add child/sibling, edit, delete, toggle complete, create todo, generate image, and decompose buttons
- Inline text editing for node names

## Files
- `app/(tabs)/goals.tsx` -- Screen wrapper with header and state management
- `components/mindmap/MindMapCanvas.tsx` -- Core SVG canvas with gesture support
- `components/mindmap/MindMapNode.tsx` -- Individual node SVG component
- `components/mindmap/MindMapEdge.tsx` -- Bezier curve edge connections
- `components/mindmap/MindMapControls.tsx` -- Floating action bar
- `components/mindmap/useMindMapLayout.ts` -- Tree layout algorithm
- `components/mindmap/useMindMapGestures.ts` -- Pan/pinch gesture hook

## Test plan
- [ ] Verify mind map renders with default root node
- [ ] Add child nodes and verify tree layout spacing
- [ ] Test pan and pinch-to-zoom gestures
- [ ] Test node selection and action bar visibility
- [ ] Test inline node name editing
- [ ] Test node deletion with cascade to children
- [ ] Test status toggle (PENDING/COMPLETED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)