### PR TITLE
fix: 비전보드 전환버튼 카드 가림 + 시각화 입력창 키보드 간격 제거

### DIFF
--- a/components/VisionBoard.tsx
+++ b/components/VisionBoard.tsx
@@ -89,8 +89,12 @@ const VisionBoard: React.FC<VisionBoardProps> = ({ nodes, links, onNodeClick, on
       <div className={`absolute inset-0 pointer-events-none ${isLight ? 'opacity-[0.02]' : 'opacity-[0.03]'}`}
         style={{ backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E")` }} />
 
-      {/* Bento Grid */}
-      <div className={`vb-grid relative w-full h-full ${isLight ? 'p-2.5 md:p-4' : 'p-2 md:p-3'}`}>
+      {/* Bento Grid — extra top padding so the floating GoalViewSwitcher pill
+          (top-2 + safe-area, ~44px tall) never covers the hero card image */}
+      <div
+        className={`vb-grid relative w-full h-full ${isLight ? 'p-2.5 md:p-4' : 'p-2 md:p-3'}`}
+        style={{ paddingTop: 'calc(env(safe-area-inset-top) + 60px)' }}
+      >
         {slots.map((node, index) => {
           const isHero = index === 0;
           const isEmpty = !node;

--- a/components/visualization/ChatInput.tsx
+++ b/components/visualization/ChatInput.tsx
@@ -67,29 +67,6 @@ const ChatInput: FC<ChatInputProps> = ({
     if (focusSignal > 0) textareaRef.current?.focus();
   }, [focusSignal]);
 
-  const [keyboardHeight, setKeyboardHeight] = useState(0);
-
-  useEffect(() => {
-    const nav = navigator as unknown as {
-      virtualKeyboard?: {
-        overlaysContent: boolean;
-        boundingRect: DOMRect;
-        addEventListener: (event: string, fn: () => void) => void;
-        removeEventListener: (event: string, fn: () => void) => void;
-      };
-    };
-
-    if (!nav.virtualKeyboard) return;
-
-    nav.virtualKeyboard.overlaysContent = true;
-    const onChange = () => {
-      setKeyboardHeight(Math.round(nav.virtualKeyboard!.boundingRect.height));
-    };
-
-    nav.virtualKeyboard.addEventListener('geometrychange', onChange);
-    return () => nav.virtualKeyboard!.removeEventListener('geometrychange', onChange);
-  }, []);
-
   const handleToggle = useCallback(
     (key: keyof ChatInputProps['settings']) => {
       onSettingsChange({ ...settings, [key]: !settings[key] });
@@ -144,16 +121,6 @@ const ChatInput: FC<ChatInputProps> = ({
     <div
       data-coach-anchor
       className="apple-glass-header flex flex-col gap-2 px-3 pb-3 pt-2"
-      style={keyboardHeight > 0
-        ? {
-          position: 'fixed',
-          bottom: `${keyboardHeight}px`,
-          left: 0,
-          right: 0,
-          zIndex: 60,
-          paddingBottom: 12,
-        }
-        : undefined}
     >
       {referenceImages.length > 0 && (
         <div className="flex gap-2 px-1">

--- a/components/visualization/VisualizationTab.tsx
+++ b/components/visualization/VisualizationTab.tsx
@@ -56,6 +56,59 @@ export default function VisualizationTab({
   const chat = useDreamChat(language);
   const focusTrapRef = useFocusTrap(isOpen);
 
+  // 모바일 소프트 키보드가 열리면 하단 도크 예약 공간(pb-16)을 키보드 높이만큼으로
+  // 바꿔, 입력창이 키보드 바로 위에 붙도록 한다. 입력창을 position:fixed 로 띄우면
+  // 상위 backdrop-filter 글래스 패널이 컨테이닝 블록이 되어 도크 높이(64px)만큼
+  // 어긋나므로, 대신 셸의 하단 패딩만 조절해 입력창을 일반 흐름에 둔다.
+  //   · 터치 기기에서 텍스트 필드가 포커스됨 == 키보드 열림 (모드 무관 신뢰 신호)
+  //   · resizes-visual(iOS/크롬): visualViewport 인셋 = 키보드 높이 → 그만큼 패딩
+  //   · resizes-content(삼성/구안드로이드): 레이아웃이 이미 줄어 인셋≈0 → 패딩 0
+  const [keyboardPad, setKeyboardPad] = useState<number | null>(null);
+  useEffect(() => {
+    const nav = navigator as unknown as { virtualKeyboard?: { overlaysContent: boolean } };
+    if (nav.virtualKeyboard) nav.virtualKeyboard.overlaysContent = true;
+
+    const coarse = window.matchMedia?.('(pointer: coarse)').matches ?? false;
+    const vv = window.visualViewport;
+    let focused = false;
+
+    const isField = (el: EventTarget | null) =>
+      el instanceof HTMLElement && (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT');
+
+    const compute = () => {
+      if (!focused || !coarse) {
+        setKeyboardPad(null);
+        return;
+      }
+      const inset = vv ? Math.max(0, Math.round(window.innerHeight - vv.height - vv.offsetTop)) : 0;
+      setKeyboardPad(inset);
+    };
+
+    const onFocusIn = (e: FocusEvent) => {
+      if (isField(e.target)) {
+        focused = true;
+        compute();
+      }
+    };
+    const onFocusOut = () => {
+      window.setTimeout(() => {
+        focused = isField(document.activeElement);
+        compute();
+      }, 50);
+    };
+
+    document.addEventListener('focusin', onFocusIn);
+    document.addEventListener('focusout', onFocusOut);
+    vv?.addEventListener('resize', compute);
+    vv?.addEventListener('scroll', compute);
+    return () => {
+      document.removeEventListener('focusin', onFocusIn);
+      document.removeEventListener('focusout', onFocusOut);
+      vv?.removeEventListener('resize', compute);
+      vv?.removeEventListener('scroll', compute);
+    };
+  }, []);
+
   useEffect(() => {
     if (!isOpen) {
       setView('tabs');
@@ -143,7 +196,11 @@ export default function VisualizationTab({
     : '✨ Dream is ready — View result';
 
   return (
-    <div ref={focusTrapRef} className="apple-tab-shell fixed inset-0 z-50 flex flex-col pb-16 font-body">
+    <div
+      ref={focusTrapRef}
+      className="apple-tab-shell fixed inset-0 z-50 flex flex-col pb-16 font-body"
+      style={keyboardPad !== null ? { paddingBottom: keyboardPad } : undefined}
+    >
       <div className="apple-glass-header flex justify-center pt-3 pb-3">
         <DreamPillSwitcher activeTab={pillTab} onTabChange={setPillTab} />
       </div>


### PR DESCRIPTION
## 두 UI 버그 수정 (스크린샷 기반)

### 1. 비전보드 전환버튼이 카드 이미지를 가림
떠 있는 `GoalViewSwitcher` 알약(`top-2` + safe-area, ~44px)이 히어로 카드 이미지 위를 덮고 있었음. `vb-grid` 상단에 `calc(env(safe-area-inset-top) + 60px)` 패딩을 추가해 카드가 알약 아래에서 시작하도록 함. (실측: 첫 카드 60px, 알약 바닥 54px → 6px 여유)

### 2. 시각화 입력창과 키보드 사이 빈 간격
**원인:** 입력창을 `position: fixed`로 띄웠는데, 상위 `backdrop-filter` 글래스 패널이 fixed의 컨테이닝 블록이 되어 하단 도크 예약(`pb-16`, 64px)만큼 키보드와 어긋남. 또한 삼성 인터넷은 `virtualKeyboard` API 미지원이라 기존 위치 보정이 아예 동작하지 않았음.

**해결:** 입력창은 일반 흐름에 두고, 키보드가 열리면(터치 기기에서 텍스트 필드 포커스) 셸의 하단 패딩을 `visualViewport` 인셋만큼으로 바꿔 입력창이 키보드 바로 위에 붙도록 함.
- resizes-visual(iOS/크롬): 인셋 = 키보드 높이 → 그만큼 패딩
- resizes-content(삼성/구안드로이드): 레이아웃이 이미 줄어 인셋≈0 → 패딩 0

### 검증
- `npm run build` 통과 (master 머지 후 재빌드 포함)
- 브라우저 실측: 비전보드 6px 여유, 키보드 시뮬레이션 시 입력창이 키보드 위 1px까지 붙음, 포커스 해제 시 원위치 복귀, 키보드 없을 때 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)